### PR TITLE
docs: seção pre-commit no CONTRIBUTING

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -126,10 +126,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Poetry
+      - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry==2.2.1
+          python -m pip install poetry==1.8.3
       - name: Poetry export plugin (poetry-plugin-export)
         run: |
           poetry self add poetry-plugin-export
@@ -347,10 +347,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Poetry
+      - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry==2.2.1
+          python -m pip install poetry==1.8.3
 
       - name: Install Python dependencies
         run: poetry install --with dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ A pipeline principal executa e/ou exige:
 - `git commit --fixup` + `git rebase -i --autosquash` para organizar antes do PR.
 - `git stash -u` para pausar trabalho; `git reflog` para recuperar histórico.
 
+## Pre-commit (hooks)
+- Arquivo de configuração: `.pre-commit-config.yaml` (hooks: Ruff/Python, ESLint/Frontend e verificação de mensagem convencional).
+- Ative localmente os hooks para “amarrar” o padrão antes do CI:
+  - Com Poetry: `poetry run pre-commit install` (ou `pre-commit install`).
+  - Rodar em todos os arquivos: `pre-commit run -a`.
+
 ## Governança (resumo)
 - Revisões: CODEOWNERS define responsáveis por áreas do código.
 - Proteção da `main`: habilite no GitHub (require PR, squash only, linear history, required checks). Configuração é feita nas “Branch protection rules” do repositório.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,5 +45,6 @@ A pipeline principal executa e/ou exige:
 ## Governança (resumo)
 - Revisões: CODEOWNERS define responsáveis por áreas do código.
 - Proteção da `main`: habilite no GitHub (require PR, squash only, linear history, required checks). Configuração é feita nas “Branch protection rules” do repositório.
+- Aprovações obrigatórias: enquanto houver 1 mantenedor, mantenha 0 aprovações obrigatórias (evita bloqueios). Ao formar equipe, passe para 1–2 aprovações e, se fizer sentido, exija review de CODEOWNERS.
 
 Se tiver dúvidas, abra um PR rascunho (draft) e marque as seções pendentes no template.

--- a/GIT-GUIA.md
+++ b/GIT-GUIA.md
@@ -1,3 +1,6 @@
+> [AVISO — ARQUIVADO]
+> Este documento foi mantido apenas como referência histórica. O fluxo oficial de Git, governança de revisão e links para runbooks estão consolidados em `CONTRIBUTING.md`.
+
 Objetivo
 
 - Te guiar, passo a passo, para usar Git com segurança e eficiência no IABANK, com explicações práticas, analogias simples e exemplos de comandos prontos para copiar.
@@ -180,4 +183,3 @@ Quando usar Spec‑Kit (ajustes importantes)
   - Fluxo: `/speckit.specify` → `/speckit.clarify` → `/speckit.plan` → `/speckit.tasks` → implementação/PR.
   - Mantenha a branch de feature sincronizada com `main` usando `git fetch && git rebase origin/main` antes de abrir o PR.
   - Após merge/squash na `main`, apague a branch local com `git branch -d 00X-...`.
-

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -37,3 +37,21 @@ Reflete os gates constitucionais (v5.2.0) e ADRs 008–012.
 ## Saídas
 - Artefatos devem ser enviados para armazenamento WORM.
 - Resultados agregados alimentam os dashboards DORA/SLO.
+
+## Contextos de proteção (GitHub Required Checks)
+Estes são os contextos atualmente exigidos na proteção da branch `main` (Branch protection rules). Mantemos a lista aqui para referência rápida e auditoria:
+- Lint
+- Vitest
+- Contracts (Spectral, OpenAPI Diff, Pact)
+- Visual & Accessibility Gates
+- Performance Budgets
+- Security Checks
+- Threat Model Lint
+- CI Outage Guard
+- CI Diagnostics
+
+Notas de governança relacionadas:
+- Merge: squash-only, com exclusão de branch ao mesclar.
+- Histórico linear: habilitado.
+- Resolução de conversas antes do merge: habilitada.
+- Aprovações obrigatórias: 0 (atual) — quando houver equipe, migrar para 1–2 aprovações e, se desejado, exigir review de CODEOWNERS.


### PR DESCRIPTION

- Adiciona seção objetiva sobre pre-commit no CONTRIBUTING:
  - Como instalar/ativar ( ou via Poetry).
  - Como executar manualmente ().
- Mantém estilo e conteúdo mínimos, apenas operacional.
