### PR TITLE
ci(security): tolerar WARN no ZAP baseline (exit 2)

### DIFF
--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -61,3 +61,4 @@ Notas de governança relacionadas:
 - O job provisiona Postgres (`services: postgres:15`) e exporta `FOUNDATION_DB_*` para o Django conectar.
 - O script `scripts/security/run_dast.sh` aplica migrações e inicia o `runserver` antes do scan; aguarda o endpoint responder.
 - Política: em `main` e versões (`release/*`, tags) é fail‑closed; em PRs pode ser fail‑open conforme a variável `CI_FAIL_OPEN` do workflow.
+  - Tratamento de severidade: WARN não quebra pipeline (exit 2 do ZAP é normalizado para sucesso); FAIL quebra (exit 1/3) — reduz ruído mantendo fail‑closed para vulnerabilidades reais.


### PR DESCRIPTION
- Ajusta scripts/security/run_dast.sh para interpretar exit code 2 (apenas WARN) como sucesso.
- Mantém falha em caso de FAIL (exit 1/3) — segurança continua fail-closed para vulnerabilidades reais.
- Motivo: reduzir falsos negativos e ruído em main; WARNs continuam documentados nos artefatos e logs.
