### PR TITLE
ci(security): corrigir Safety no SCA (3.6.2)

### DIFF
--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -61,3 +61,4 @@ Notas de governança relacionadas:
 - O job provisiona Postgres (`services: postgres:15`) e exporta `FOUNDATION_DB_*` para o Django conectar.
 - O script `scripts/security/run_dast.sh` aplica migrações e inicia o `runserver` antes do scan; aguarda o endpoint responder.
 - Política: em `main` e versões (`release/*`, tags) é fail‑closed; em PRs pode ser fail‑open conforme a variável `CI_FAIL_OPEN` do workflow.
+  - Tratamento de severidade: WARN não quebra pipeline (exit 2 do ZAP é normalizado para sucesso); FAIL quebra (exit 1/3) — reduz ruído mantendo fail‑closed para vulnerabilidades reais.

--- a/scripts/security/run_python_sca.sh
+++ b/scripts/security/run_python_sca.sh
@@ -31,13 +31,13 @@ PY
   else
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
   fi
-  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
+  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.6.2"
   PIP_AUDIT_CMD=("${POETRY_BIN}" "run" "pip-audit")
   SAFETY_CMD=("${POETRY_BIN}" "run" "safety")
 else
   echo "Poetry não encontrado; utilizando ambiente global para dependências Python." >&2
   python -m pip install --quiet --upgrade pip
-  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
+  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.6.2"
   pip freeze > "${REQ_FILE}"
   PIP_AUDIT_CMD=("pip-audit")
   SAFETY_CMD=("safety")


### PR DESCRIPTION
- Atualiza scripts/security/run_python_sca.sh para usar safety==3.6.2 (mesma versão já instalada no job).
- Evita falha do pip-audit step por tentativa de instalar safety==3.3.4 inexistente.
- Mantém pip-audit==2.7.3.
