### PR TITLE
ci/security pip audit fix

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -392,9 +392,9 @@ jobs:
             sleep 2;
           done
 
-      - name: Instalar ferramentas de segurança
+      - name: Instalar ferramentas de segurança (SAST)
         run: |
-          poetry run python -m pip install --quiet semgrep==1.94.0 pip-audit==2.7.3 safety==3.6.2
+          poetry run python -m pip install --quiet semgrep==1.94.0
 
       - name: SAST (Semgrep)
         id: security_sast

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -61,3 +61,4 @@ Notas de governança relacionadas:
 - O job provisiona Postgres (`services: postgres:15`) e exporta `FOUNDATION_DB_*` para o Django conectar.
 - O script `scripts/security/run_dast.sh` aplica migrações e inicia o `runserver` antes do scan; aguarda o endpoint responder.
 - Política: em `main` e versões (`release/*`, tags) é fail‑closed; em PRs pode ser fail‑open conforme a variável `CI_FAIL_OPEN` do workflow.
+  - Tratamento de severidade: WARN não quebra pipeline (exit 2 do ZAP é normalizado para sucesso); FAIL quebra (exit 1/3) — reduz ruído mantendo fail‑closed para vulnerabilidades reais.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       name: 'lighthouse',
       testDir: './tests/performance',
       testMatch: ['**/*.spec.ts'],
+      timeout: 180_000,
       retries: process.env.CI ? 1 : 0,
       use: {
         ...devices['Desktop Chrome'],

--- a/scripts/security/run_python_sca.sh
+++ b/scripts/security/run_python_sca.sh
@@ -31,13 +31,13 @@ PY
   else
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
   fi
-  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
+  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.6.2"
   PIP_AUDIT_CMD=("${POETRY_BIN}" "run" "pip-audit")
   SAFETY_CMD=("${POETRY_BIN}" "run" "safety")
 else
   echo "Poetry não encontrado; utilizando ambiente global para dependências Python." >&2
   python -m pip install --quiet --upgrade pip
-  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
+  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.6.2"
   pip freeze > "${REQ_FILE}"
   PIP_AUDIT_CMD=("pip-audit")
   SAFETY_CMD=("safety")


### PR DESCRIPTION
- **ci(security): tratar exit code 2 do ZAP (WARN) como sucesso; falhar apenas em FAIL**
- **docs(ci): explicitar tolerância a WARN no DAST (ZAP) — FAILs continuam fail-closed**
- **ci(security): alinhar Safety para 3.6.2 no script de SCA (evitar erro de versão inexistente)**
- **ci(security,perf): corrigir pip-audit (-r sem project_path) e aumentar timeout do Lighthouse (best-of-2)**
