### PR TITLE
ci/security pip audit fix

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -307,6 +307,7 @@ jobs:
           path: artifacts/k6-smoke.json
 
       - name: Publicar relatórios Lighthouse
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: performance-lighthouse-budgets

--- a/frontend/tests/performance/support/lighthouse.ts
+++ b/frontend/tests/performance/support/lighthouse.ts
@@ -201,6 +201,14 @@ export async function enforceLighthouseBudgets(page: Page): Promise<LighthouseBu
       metrics.tbt <= METRIC_BUDGETS.tbt &&
       metrics.cls <= METRIC_BUDGETS.cls;
 
+    if (!passed) {
+      // Ajuda na depuração em CI quando budgets estouram (sem depender apenas de artifacts)
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Lighthouse budgets] FAILED: metrics=${JSON.stringify(metrics)} budgets=${JSON.stringify(METRIC_BUDGETS)}`
+      );
+    }
+
     return {
       passed,
       details: summary,

--- a/scripts/security/run_python_sca.sh
+++ b/scripts/security/run_python_sca.sh
@@ -26,8 +26,19 @@ if command -v "${POETRY_BIN}" >/dev/null 2>&1; then
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
   fi
   "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.6.2"
-  PIP_AUDIT_CMD=("${POETRY_BIN}" "run" "pip-audit")
-  SAFETY_CMD=("${POETRY_BIN}" "run" "safety")
+  # Resolve binários absolutos dentro do venv do Poetry para permitir executar fora do CWD do projeto
+  PIP_AUDIT_BIN="$(${POETRY_BIN} run which pip-audit)"
+  SAFETY_BIN="$(${POETRY_BIN} run which safety)"
+  if [[ -z "${PIP_AUDIT_BIN}" || ! -x "${PIP_AUDIT_BIN}" ]]; then
+    echo "pip-audit não encontrado no ambiente do Poetry." >&2
+    exit 1
+  fi
+  if [[ -z "${SAFETY_BIN}" || ! -x "${SAFETY_BIN}" ]]; then
+    echo "safety não encontrado no ambiente do Poetry." >&2
+    exit 1
+  fi
+  PIP_AUDIT_CMD=("${PIP_AUDIT_BIN}")
+  SAFETY_CMD=("${SAFETY_BIN}")
 else
   echo "Poetry não encontrado; utilizando ambiente global para dependências Python." >&2
   python -m pip install --quiet --upgrade pip


### PR DESCRIPTION
- **ci(security): tratar exit code 2 do ZAP (WARN) como sucesso; falhar apenas em FAIL**
- **docs(ci): explicitar tolerância a WARN no DAST (ZAP) — FAILs continuam fail-closed**
- **ci(security): alinhar Safety para 3.6.2 no script de SCA (evitar erro de versão inexistente)**
- **ci(security,perf): corrigir pip-audit (-r sem project_path) e aumentar timeout do Lighthouse (best-of-2)**
- **ci(security): evitar instalação duplicada de pip-audit/safety (script gerencia SCA); manter apenas Semgrep no job**
- **ci(security,perf): corrigir pip-audit usando binário do venv; publicar relatórios Lighthouse sempre (if: always())**
