### PR TITLE
docs(contributing): referências rápidas CI/Workflows (gh CLI) @SC-005

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,16 +28,19 @@ A pipeline principal executa e/ou exige:
 - Threat model lint.
 - CI Outage Guard: fail‑open em branches não release para ferramentas de QA; fail‑closed em `main`/`release/*`/`hotfix/*`.
 
-### Referências rápidas de CI/Workflows
+### Onde consultar gates do CI (sem duplicar valores)
 - Workflow principal: `.github/workflows/frontend-foundation.yml:1`
-- Inspecionar runs (gh CLI):
+- Como localizar regras no YAML:
+  - Vitest (coverage gate): procurar `FOUNDATION_COVERAGE_BRANCHES` e os passos "Run Vitest (coverage gate)".
+    - Comando: `rg -n "FOUNDATION_COVERAGE_BRANCHES|Run Vitest" .github/workflows/frontend-foundation.yml`
+  - Segurança (fail-open/closed): procurar `CI_ENFORCE_FULL_SECURITY` e `CI_FAIL_OPEN`.
+    - Comando: `rg -n "CI_ENFORCE_FULL_SECURITY|CI_FAIL_OPEN" .github/workflows/frontend-foundation.yml`
+  - Performance (Lighthouse/k6): procurar "Performance Budgets" e "Lighthouse".
+    - Comando: `rg -n "Performance Budgets|Lighthouse" .github/workflows/frontend-foundation.yml`
+- Inspecionar runs no GitHub Actions (gh CLI):
   - `gh run list --limit 10`
-  - `gh run view <RUN_ID>` (ou somente falhas: `--log-failed`)
-  - `gh run rerun <RUN_ID>` (ou `--failed` para reexecutar só o que falhou)
-- Gates típicos por evento:
-  - Vitest branches: PR ≥ 84.5%, main/releases ≥ 84.8%
-  - Segurança: fail‑closed em main/releases; fail‑open em PR/dev
-  - Performance budgets: “hard” em main; “soft” em PR
+  - `gh run view <RUN_ID>` (ou apenas falhas: `--log-failed`)
+  - `gh run rerun <RUN_ID>` (ou `--failed` para só os jobs que falharam)
 
 ## Runbooks úteis
 - Outage (Chromatic/Lighthouse/Axe): `docs/runbooks/frontend-outage.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,17 @@ A pipeline principal executa e/ou exige:
 - Threat model lint.
 - CI Outage Guard: fail‑open em branches não release para ferramentas de QA; fail‑closed em `main`/`release/*`/`hotfix/*`.
 
+### Referências rápidas de CI/Workflows
+- Workflow principal: `.github/workflows/frontend-foundation.yml:1`
+- Inspecionar runs (gh CLI):
+  - `gh run list --limit 10`
+  - `gh run view <RUN_ID>` (ou somente falhas: `--log-failed`)
+  - `gh run rerun <RUN_ID>` (ou `--failed` para reexecutar só o que falhou)
+- Gates típicos por evento:
+  - Vitest branches: PR ≥ 84.5%, main/releases ≥ 84.8%
+  - Segurança: fail‑closed em main/releases; fail‑open em PR/dev
+  - Performance budgets: “hard” em main; “soft” em PR
+
 ## Runbooks úteis
 - Outage (Chromatic/Lighthouse/Axe): `docs/runbooks/frontend-outage.md`.
 - Renovate Validation (Node 22.13 no job; `renovate-config-validator`): `docs/runbooks/renovate-validation.md`.


### PR DESCRIPTION
Adiciona seção curta no CONTRIBUTING com links de referência ao workflow principal e comandos gh CLI para inspeção/rerun de runs, evitando duplicação no README.\n\n- Workflow: .github/workflows/frontend-foundation.yml\n- Comandos: gh run list/view/rerun\n- Observações de gates: cobertura Vitest (PR/main), segurança (fail-open/closed), performance budgets (soft/hard)\n\nSem alterações de código/CI. Apenas documentação para reduzir atrito operacional.