### PR TITLE
ci: restaurar quick perf/security offline

### DIFF
--- a/.github/workflows/quick-perf-security.yml
+++ b/.github/workflows/quick-perf-security.yml
@@ -16,6 +16,15 @@ jobs:
   performance:
     name: Performance Budgets (quick)
     runs-on: ubuntu-latest
+    env:
+      VITE_API_BASE_URL: https://api.iabank.test
+      VITE_TENANT_DEFAULT: tenant-alfa
+      VITE_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+      VITE_OTEL_SERVICE_NAME: frontend-foundation
+      VITE_OTEL_RESOURCE_ATTRIBUTES: service.namespace=iabank,service.version=0.1.0,environment=ci
+      VITE_FOUNDATION_CSP_NONCE: ci-nonce-fallback
+      VITE_FOUNDATION_TRUSTED_TYPES_POLICY: foundation-ui
+      VITE_FOUNDATION_PGCRYPTO_KEY: ci-only-pgcrypto-key
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,6 +60,7 @@ jobs:
         run: pnpm perf:lighthouse
 
       - name: Publicar relatórios Lighthouse
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: performance-lighthouse-budgets
@@ -86,8 +96,8 @@ jobs:
         run: poetry run bash scripts/security/run_python_sca.sh safety
 
       - name: Publicar artefatos SCA
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: python-sca
           path: artifacts/python-sca
-

--- a/frontend/src/app/providers/telemetry.test.tsx
+++ b/frontend/src/app/providers/telemetry.test.tsx
@@ -69,9 +69,9 @@ describe('TelemetryProvider', () => {
 
     expect(screen.getByText('child')).toBeInTheDocument();
     await waitFor(() => expect(warnSpy).toHaveBeenCalled());
-    const msg = String(warnSpy.mock.calls[0][0] ?? '');
-    // Aceita mensagem antiga e nova para reduzir flakiness entre branches
-    expect(msg).toMatch(/\[telemetry\] (Falha ao iniciar coleta OTEL|Bootstrap configurado falhou)/);
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      '[telemetry] Falha ao iniciar coleta OTEL; execução seguirá sem telemetria.',
+    );
 
     unmount();
     telemetryModule.resetTelemetryBootstrap();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,7 +52,6 @@ export default defineConfig({
           if (id.includes('node_modules')) {
             if (id.includes('@opentelemetry')) return 'vendor-otel';
             if (id.includes('@sentry')) return 'vendor-sentry';
-            if (id.includes('react')) return 'vendor-react';
           }
         },
       },

--- a/scripts/security/run_python_sca.sh
+++ b/scripts/security/run_python_sca.sh
@@ -8,71 +8,217 @@ REPORT_DIR="${PYTHON_SCA_REPORT_DIR:-${ROOT_DIR}/artifacts/python-sca}"
 mkdir -p "${REPORT_DIR}"
 
 REQ_FILE="$(mktemp)"
+TMP_SCAN_DIR="$(mktemp -d)"
 cleanup() {
   rm -f "${REQ_FILE}"
+  rm -rf "${TMP_SCAN_DIR}"
 }
 trap cleanup EXIT
 
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+create_tool_venv() {
+  local name="$1"
+  shift
+  local dest="${TMP_SCAN_DIR}/${name}-venv"
+  "${PYTHON_BIN}" -m venv "${dest}"
+  "${dest}/bin/python" -m pip install --quiet --upgrade pip
+  if (($#)); then
+    "${dest}/bin/python" -m pip install --quiet "$@"
+  fi
+  echo "${dest}"
+}
+
+RUN_PIP_AUDIT=false
+RUN_SAFETY=false
+case "${MODE}" in
+  all)
+    RUN_PIP_AUDIT=true
+    RUN_SAFETY=true
+    ;;
+  pip-audit)
+    RUN_PIP_AUDIT=true
+    ;;
+  safety)
+    RUN_SAFETY=true
+    ;;
+  *)
+    echo "Modo desconhecido '${MODE}'. Use 'all', 'pip-audit' ou 'safety'." >&2
+    exit 2
+    ;;
+esac
+
+SAFETY_VERSION_WITH_API="3.6.2"
+SAFETY_VERSION_OFFLINE="2.3.5"
+if [[ -n "${SAFETY_API_KEY:-}" ]]; then
+  SAFETY_PKG_VERSION="${SAFETY_VERSION_WITH_API}"
+else
+  # Safety 3.x exige autenticação; com fallback offline usamos a série 2.3.x.
+  SAFETY_PKG_VERSION="${SAFETY_VERSION_OFFLINE}"
+fi
+
 if command -v "${POETRY_BIN}" >/dev/null 2>&1; then
-  # Poetry 2.x requer plugin de export; se falhar, faz fallback para freeze do env
+  # Em Poetry 1.8.x, o comando export depende de plugin; se indisponível, faz fallback para freeze.
   if ! "${POETRY_BIN}" export --with dev --format requirements.txt --output "${REQ_FILE}" >/dev/null 2>&1; then
     echo "Poetry export indisponível; usando freeze do ambiente virtual gerenciado pelo Poetry." >&2
-    # Garante pip atualizado dentro do env
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
-    "${POETRY_BIN}" run python - <<'PY'
-import pkgutil, subprocess, sys
-try:
-    import pip
-except Exception:
-    pass
-subprocess.check_call([sys.executable, '-m', 'pip', 'freeze'], stdout=open(sys.argv[1], 'w'))
-PY
-    "${REQ_FILE}"
+    # Gera requirements a partir do ambiente do Poetry
+    "${POETRY_BIN}" run python -m pip freeze > "${REQ_FILE}"
   else
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
   fi
-  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
-  PIP_AUDIT_CMD=("${POETRY_BIN}" "run" "pip-audit")
-  SAFETY_CMD=("${POETRY_BIN}" "run" "safety")
 else
   echo "Poetry não encontrado; utilizando ambiente global para dependências Python." >&2
-  python -m pip install --quiet --upgrade pip
-  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
-  pip freeze > "${REQ_FILE}"
-  PIP_AUDIT_CMD=("pip-audit")
-  SAFETY_CMD=("safety")
+  "${PYTHON_BIN}" -m pip install --quiet --upgrade pip
+  "${PYTHON_BIN}" -m pip freeze > "${REQ_FILE}"
 fi
 
-if [[ "${MODE}" == "all" || "${MODE}" == "pip-audit" ]]; then
+if [[ "${RUN_PIP_AUDIT}" == true ]]; then
+  PIP_AUDIT_VENV="$(create_tool_venv "pip-audit" "pip-audit==2.7.3")"
+  PIP_AUDIT_CMD=("${PIP_AUDIT_VENV}/bin/pip-audit")
+fi
+
+if [[ "${RUN_SAFETY}" == true ]]; then
+  SAFETY_VENV="$(create_tool_venv "safety" "safety==${SAFETY_PKG_VERSION}")"
+  SAFETY_CMD=("${SAFETY_VENV}/bin/safety")
+fi
+
+if [[ "${RUN_PIP_AUDIT}" == true ]]; then
   PIP_AUDIT_REPORT="${REPORT_DIR}/pip-audit.json"
-  "${PIP_AUDIT_CMD[@]}" \
-    --requirement "${REQ_FILE}" \
-    --severity HIGH \
-    --format json \
-    --output "${PIP_AUDIT_REPORT}"
+  # Executa a partir de um diretório vazio para evitar que a CLI infira project_path
+  # quando há um pyproject.toml no CWD, o que conflita com -r/--requirement em algumas versões.
+  (
+    cd "${TMP_SCAN_DIR}" >/dev/null
+    "${PIP_AUDIT_CMD[@]}" \
+      --requirement "${REQ_FILE}" \
+      --format json \
+      --output "${PIP_AUDIT_REPORT}" \
+      --progress-spinner off
+  )
   echo "Relatório do pip-audit disponível em ${PIP_AUDIT_REPORT}."
 fi
 
-if [[ "${MODE}" == "all" || "${MODE}" == "safety" ]]; then
-  SAFETY_REPORT="${REPORT_DIR}/safety.json"
-  # Desabilita telemetria do Safety para evitar ruído na saída JSON
-  export SAFETY_DISABLE_TELEMETRY=1
+if [[ "${RUN_SAFETY}" == true ]]; then
+  # Hardening do ambiente para saídas determinísticas e UTF-8
+  export PYTHONUTF8=1
+  export LANG=C
+  export LC_ALL=C
+  export CI=1
+  export PYTHONUNBUFFERED=1
+  export PYTHONIOENCODING=UTF-8
+  export SAFETY_REQUEST_TIMEOUT=${SAFETY_REQUEST_TIMEOUT:-30}
 
+  SAFETY_DIR="${REPORT_DIR}"
+  mkdir -p "${SAFETY_DIR}"
+  SAFETY_JSON_TMP="${SAFETY_DIR}/safety.json.tmp"
+  SAFETY_JSON_FINAL="${SAFETY_DIR}/safety.json"
+  SAFETY_STDERR_LOG="${SAFETY_DIR}/safety.stderr.log"
+
+  # Executa Safety em modo JSON estrito via stdout e captura stderr separado
   set +e
-  # Usa saída em arquivo via flag nativa para garantir JSON limpo
-  "${SAFETY_CMD[@]}" check --stdin --json --output "${SAFETY_REPORT}" < "${REQ_FILE}"
-  SAFETY_EXIT=$?
-  set -e
-
-  if [[ ! -s "${SAFETY_REPORT}" ]]; then
-    echo "Safety não gerou relatório JSON válido." >&2
-    exit 1
+  # Descobre suporte à flag de telemetria opcional nesta versão (best-effort)
+  SAFETY_FLAGS=()
+  if "${SAFETY_CMD[@]}" scan --help 2>/dev/null | grep -q -- '--disable-optional-telemetry'; then
+    SAFETY_FLAGS+=("--disable-optional-telemetry")
+  fi
+  SAFETY_JSON_FORMAT_FLAG=()
+  if "${SAFETY_CMD[@]}" check --help 2>/dev/null | grep -q -- '--json-output-format'; then
+    SAFETY_JSON_FORMAT_FLAG=(--json-output-format 1.1)
   fi
 
-  export SAFETY_REPORT_PATH="${SAFETY_REPORT}"
+  # Registrar versão do Safety para diagnóstico
+  { "${SAFETY_CMD[@]}" --version || true; } >>"${SAFETY_STDERR_LOG}" 2>&1
+
+  SAFETY_SUBCOMMAND="scan"
+  if [[ -z "${SAFETY_API_KEY:-}" ]]; then
+    SAFETY_SUBCOMMAND="check"
+    echo "[Safety] SAFETY_API_KEY não definido; usando fallback 'check' (offline)." >&2
+  fi
+
+  if [[ "${SAFETY_SUBCOMMAND}" == "scan" ]]; then
+    "${SAFETY_CMD[@]}" scan \
+      -r "${REQ_FILE}" \
+      --output json \
+      ${SAFETY_FLAGS[@]+"${SAFETY_FLAGS[@]}"} \
+      >"${SAFETY_JSON_TMP}" 2>"${SAFETY_STDERR_LOG}"
+  else
+    "${SAFETY_CMD[@]}" check \
+      --file "${REQ_FILE}" \
+      --output json \
+      ${SAFETY_JSON_FORMAT_FLAG[@]+"${SAFETY_JSON_FORMAT_FLAG[@]}"} \
+      >"${SAFETY_JSON_TMP}" 2>"${SAFETY_STDERR_LOG}"
+  fi
+  SAFETY_EXIT=$?
+  if [[ ${SAFETY_EXIT} -ne 0 ]]; then
+    # Alguns ambientes retornam 1 quando encontra vulnerabilidades; aceitável para processamento
+    true
+  fi
+  set -e
+
+  # Validar JSON antes de mover para o arquivo final
+  "${PYTHON_BIN}" - <<PY
+import json, sys, pathlib
+tmp = pathlib.Path(r"${SAFETY_JSON_TMP}")
+err = pathlib.Path(r"${SAFETY_STDERR_LOG}")
+raw = ''
+if tmp.exists():
+    raw = tmp.read_text(encoding='utf-8')
+
+def try_parse(text: str):
+    try:
+        json.loads(text)
+        return True
+    except Exception:
+        return False
+
+if not raw.strip():
+    print("ERRO: safety.json vazio; veja STDERR a seguir.", file=sys.stderr)
+    try:
+        est = err.read_text(encoding='utf-8')[:16000]
+    except Exception:
+        est = ''
+    if est:
+        print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+    sys.exit(1)
+
+if not try_parse(raw):
+    # Tenta saneamento: recorta a partir do primeiro '{' até o último '}'
+    start = raw.find('{')
+    end = raw.rfind('}')
+    if start != -1 and end != -1 and end > start:
+        candidate = raw[start:end+1]
+        if try_parse(candidate):
+            tmp.write_text(candidate, encoding='utf-8')
+        else:
+            print("ERRO: safety.json inválido mesmo após saneamento.", file=sys.stderr)
+            print("\n--- Amostra do stdout capturado (início) ---\n" + raw[:1000], file=sys.stderr)
+            try:
+                est = err.read_text(encoding='utf-8')[:16000]
+            except Exception:
+                est = ''
+            if est:
+                print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("ERRO: safety.json inválido: não foi encontrado bloco JSON.", file=sys.stderr)
+        print("\n--- Amostra do stdout capturado (início) ---\n" + raw[:1000], file=sys.stderr)
+        try:
+            est = err.read_text(encoding='utf-8')[:16000]
+        except Exception:
+            est = ''
+        if est:
+            print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+        sys.exit(1)
+PY
+  mv -f "${SAFETY_JSON_TMP}" "${SAFETY_JSON_FINAL}"
+
+  export SAFETY_REPORT_PATH="${SAFETY_JSON_FINAL}"
   export SAFETY_EXIT_CODE="${SAFETY_EXIT}"
   SAFETY_STATUS="$(
-    python <<'PY'
+    "${PYTHON_BIN}" <<'PY'
 import json
 import os
 import sys


### PR DESCRIPTION
## Contexto
- Portamos o fallback offline do Safety com troca automática scan/check
- Workflow atualiza envs VITE_* para o job de performance, alinhando com ci/diag-quickcheck

## Testes
- gh workflow run quick-perf-security.yml --ref ci/fix-quick-perf-security