### PR TITLE
ci: garantir env e resumo Lighthouse

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -279,6 +279,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     needs: contracts
+    env:
+      VITE_API_BASE_URL: https://api.iabank.test
+      VITE_TENANT_DEFAULT: tenant-alfa
+      VITE_OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+      VITE_OTEL_SERVICE_NAME: frontend-foundation
+      VITE_OTEL_RESOURCE_ATTRIBUTES: service.namespace=iabank,service.version=0.1.0,environment=ci
+      VITE_FOUNDATION_CSP_NONCE: ci-nonce-fallback
+      VITE_FOUNDATION_TRUSTED_TYPES_POLICY: foundation-ui
+      VITE_FOUNDATION_PGCRYPTO_KEY: ci-only-pgcrypto-key
+      LIGHTHOUSE_ARTIFACT_DIR: ${{ github.workspace }}/artifacts/lighthouse
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -320,7 +330,6 @@ jobs:
       - name: Executar Playwright + Lighthouse budgets (estrito)
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
-          LIGHTHOUSE_ARTIFACT_DIR: ${{ github.workspace }}/artifacts/lighthouse
           LIGHTHOUSE_TARGET_URL: http://localhost:4173/foundation/scaffold?tenant=tenant-alfa&feature=foundation-scaffold
         run: pnpm perf:lighthouse
 

--- a/frontend/tests/performance/support/lighthouse.ts
+++ b/frontend/tests/performance/support/lighthouse.ts
@@ -270,9 +270,12 @@ export async function enforceLighthouseBudgets(page: Page): Promise<LighthouseBu
     runtimeError: lhr.runtimeError ?? undefined,
   };
 
+  const summaryPath = path.join(artifactsDir, `${reportBaseName}.summary.json`);
+
   await Promise.all([
     writeFile(summary.reports.html, reportsArray.find((r): r is string => typeof r === 'string') ?? '', 'utf-8'),
     writeFile(summary.reports.json, JSON.stringify(reportsArray[0], null, 2), 'utf-8'),
+    writeFile(summaryPath, JSON.stringify(summary, null, 2), 'utf-8'),
     writeFile(summary.dashboard.json, JSON.stringify(summary, null, 2), 'utf-8'),
   ]);
 


### PR DESCRIPTION
## Contexto
- pipeline principal falhou no job Performance Budgets: preview nao renderizava (NO_FCP) e passo de verificacao nao encontrava home.summary.json.
- quick perf/security ja usava envs VITE_* e LIGHTHOUSE_ARTIFACT_DIR.

## Ajustes
- replica envs VITE_* e LIGHTHOUSE_ARTIFACT_DIR no job Performance Budgets do workflow principal.
- gera artifacts/home.summary.json no script perf/lighthouse para satisfazer step de verificacao/resumo.

## Testes
- gh workflow run frontend-foundation.yml --ref ci/fix-lighthouse-summary (run 19182617888)