### PR TITLE
docs(ci): gates estritos em PRs + remoção workflow quick + artefatos Lighthouse

### DIFF
--- a/docs/adr/adr-perf-front.md
+++ b/docs/adr/adr-perf-front.md
@@ -1,6 +1,7 @@
 # ADR — Performance Frontend (Lighthouse + k6)
 
 **Status**: Aceito — 2025-10-19  
+**Atualização**: 2025-11-08 — PRs agora são fail‑closed para Performance e Segurança; o workflow temporário “Quick Perf+Security Check” foi removido. Esta ADR permanece como registro histórico; ver PRs #50, #51 e #52 para a política vigente.
 **Owners**: Frontend Foundation Guild (tech), SRE (co-owner)  
 **Referências**: Constituição v5.2.0 (Art. IX, Art. XIII), Clarification “Perf-Front” 2025-10-12, BLUEPRINT_ARQUITETURAL.md §4
 
@@ -18,9 +19,9 @@ Sem uma decisão formal havia risco de divergência entre squads, violações da
 
 1. **Budgets Lighthouse (UX)**  
    - `frontend/lighthouse.config.mjs` mantém LCP ≤ 2.5s p95, TTI ≤ 3.0s p95, CLS ≤ 0.1.  
-   - Rodamos via job `performance` no workflow `.github/workflows/ci/frontend-foundation.yml`. Falhas:
-     - `main`/`release/*`: fail-closed (pipeline interrompe).  
-     - Outros branches: fail-open acompanhado de label `@SC-001` e alerta FinOps.
+   - Rodamos via job `performance` no workflow `.github/workflows/ci/frontend-foundation.yml`. Falhas (política vigente em 2025‑11‑08):
+     - `pull_request`, `main`, `release/*` e tags: fail-closed (pipeline interrompe).  
+     - `workflow_dispatch`: execução de sanidade, pode pular ou relaxar gates conforme configuração.
 
 2. **k6 Smoke e Métricas**  
    - `tests/performance/frontend-smoke.js` orquestra cenários críticos com baggage multi-tenant.  
@@ -46,7 +47,7 @@ Sem uma decisão formal havia risco de divergência entre squads, violações da
 - **Riscos Mitigados**:  
   - Evita regressões de UX em tenants críticos.  
   - Mantém rastreabilidade de custos das ferramentas de QA (apoio a NFR-005).  
-  - Suporta fail-open controlado quando Chromatic/Lighthouse estiverem indisponíveis, sem violar Art. IX.
+  - Nota (2025‑11‑08): fail-open controlado deixou de se aplicar a `pull_request`.
 
 ## Alternativas Consideradas
 

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -60,5 +60,5 @@ Notas de governança relacionadas:
 - Alvo do DAST: `http://127.0.0.1:8000/metrics` (exposto por `django_prometheus`).
 - O job provisiona Postgres (`services: postgres:15`) e exporta `FOUNDATION_DB_*` para o Django conectar.
 - O script `scripts/security/run_dast.sh` aplica migrações e inicia o `runserver` antes do scan; aguarda o endpoint responder.
-- Política: em `main` e versões (`release/*`, tags) é fail‑closed; em PRs pode ser fail‑open conforme a variável `CI_FAIL_OPEN` do workflow.
+- Política (atualizada em 2025‑11‑08): em PRs, `main`, `release/*` e tags é fail‑closed (sem `fail‑open`). Em `workflow_dispatch`, segue política de sanidade do workflow.
   - Tratamento de severidade: WARN não quebra pipeline (exit 2 do ZAP é normalizado para sucesso); FAIL quebra (exit 1/3) — reduz ruído mantendo fail‑closed para vulnerabilidades reais.

--- a/docs/runbooks/evidences/frontend-foundation/v1.0/README.md
+++ b/docs/runbooks/evidences/frontend-foundation/v1.0/README.md
@@ -14,8 +14,8 @@ Responsáveis: Frontend Foundation Guild / Platform
     - Vitest + Pytest: success (All files 95.17/95.17/88.88/84.75; Pytest TOTAL 87%)
     - Contracts (Spectral/OpenAPI/Pact): success
     - Visual & A11y: success (Chromatic executado em PR; test‑runner axe/WCAG sem violações)
-    - Performance: success (k6 + Lighthouse tolerantes em PR; artefatos publicados)
-    - Security Checks: success (PR = fail‑open por política)
+    - Performance: success (histórico). ATUALIZAÇÃO 2025-11-08: gates agora são estritos também em PR; continuam publicando artefatos.
+    - Security Checks: success (histórico). ATUALIZAÇÃO 2025-11-08: em PR passou a ser fail‑closed (sem fail‑open).
     - Threat Model Lint: success
 - Run manual (sanidade em main): ID 19048561651 (workflow_dispatch) — logs locais em `run.log`.
 
@@ -24,6 +24,7 @@ Responsáveis: Frontend Foundation Guild / Platform
 - Storybook estático: `frontend/storybook-static/`
 - Chromatic coverage: `frontend/chromatic-coverage.json` (em PR; cobertura por tenant tolerante)
 - Lighthouse (último): `observabilidade/data/lighthouse-latest.json`
+- Lighthouse (resumo usado pelo CI): `artifacts/lighthouse/home.summary.json`
 - k6 smoke (PR): artifact `performance-k6-smoke` (upload-artifact)
 - SBOM (PR): `sbom/frontend-foundation.json` (após geração/validação)
 

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -130,7 +130,8 @@ Pontos de Contato
 
 ### Evidências PR #12 — run verde
 - Workflow (pull_request): https://github.com/Tomvaz11/iabank/actions/runs/19050934281
-- Jobs (principais): Lint (success); Vitest/Pytest (success); Contracts (success); Visual & A11y (success — Chromatic executado; test‑runner sem violações); Performance (success — k6 e Lighthouse tolerantes); Security Checks (success — PR fail‑open); Threat Model Lint (success).
+- Jobs (principais): Lint (success); Vitest/Pytest (success); Contracts (success); Visual & A11y (success — Chromatic executado; test‑runner sem violações); Performance (success — k6 e Lighthouse tolerantes); Security Checks (success — PR fail‑open).
+  - ATUALIZAÇÃO 2025‑11‑08: gates de Performance e Segurança agora são estritos também nos PRs (fail‑closed). O workflow temporário “Quick Perf+Security Check” foi removido.
 
 Resumo consolidado
 - Consulte `RESUMO_F10_VALIDACAO_E_CI.md` para decisões, alterações e passos de operação.
@@ -190,12 +191,13 @@ Observabilidade (24–48h)
 
 - Artefatos de referência
   - Lighthouse (mais recente): `observabilidade/data/lighthouse-latest.json`.
+  - Lighthouse (resumo usado pelo CI): `artifacts/lighthouse/home.summary.json`.
   - k6 smoke (PR #12): artefato `performance-k6-smoke` publicado no run de PR: https://github.com/Tomvaz11/iabank/actions/runs/19050934281
 
-- Política final de CI
-  - Visual e Performance: pulados no `workflow_dispatch` (sanidade) e condicionais em PR/base protegida.
-  - DAST (OWASP ZAP baseline): condicionado a PR e `main`.
-  - Segurança: fail‑closed em `main/releases/tags`; PR/dispatch em fail‑open com sumário consolidado.
+- Política final de CI (atualizada em 2025‑11‑08)
+  - Visual e Performance: executam em PR e em `main`; são estritos em PR (sem continue‑on‑error). Em `workflow_dispatch` podem ser pulados conforme configuração do workflow.
+  - DAST (OWASP ZAP baseline): executa em PR e `main`; em PR é estrito (sem fail‑open). Em `workflow_dispatch`, segue política do workflow.
+  - Segurança (SAST/SCA/SBOM): fail‑closed em PR, `main`, `release/*` e tags; `fail‑open` não se aplica mais a `pull_request`.
 
 - Evidências consolidadas
   - Pacote de evidências: `docs/runbooks/evidences/frontend-foundation/v1.0/README.md`.

--- a/scripts/security/run_python_sca.sh
+++ b/scripts/security/run_python_sca.sh
@@ -8,71 +8,217 @@ REPORT_DIR="${PYTHON_SCA_REPORT_DIR:-${ROOT_DIR}/artifacts/python-sca}"
 mkdir -p "${REPORT_DIR}"
 
 REQ_FILE="$(mktemp)"
+TMP_SCAN_DIR="$(mktemp -d)"
 cleanup() {
   rm -f "${REQ_FILE}"
+  rm -rf "${TMP_SCAN_DIR}"
 }
 trap cleanup EXIT
 
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+create_tool_venv() {
+  local name="$1"
+  shift
+  local dest="${TMP_SCAN_DIR}/${name}-venv"
+  "${PYTHON_BIN}" -m venv "${dest}"
+  "${dest}/bin/python" -m pip install --quiet --upgrade pip
+  if (($#)); then
+    "${dest}/bin/python" -m pip install --quiet "$@"
+  fi
+  echo "${dest}"
+}
+
+RUN_PIP_AUDIT=false
+RUN_SAFETY=false
+case "${MODE}" in
+  all)
+    RUN_PIP_AUDIT=true
+    RUN_SAFETY=true
+    ;;
+  pip-audit)
+    RUN_PIP_AUDIT=true
+    ;;
+  safety)
+    RUN_SAFETY=true
+    ;;
+  *)
+    echo "Modo desconhecido '${MODE}'. Use 'all', 'pip-audit' ou 'safety'." >&2
+    exit 2
+    ;;
+esac
+
+SAFETY_VERSION_WITH_API="3.6.2"
+SAFETY_VERSION_OFFLINE="2.3.5"
+if [[ -n "${SAFETY_API_KEY:-}" ]]; then
+  SAFETY_PKG_VERSION="${SAFETY_VERSION_WITH_API}"
+else
+  # Safety 3.x exige autenticação; com fallback offline usamos a série 2.3.x.
+  SAFETY_PKG_VERSION="${SAFETY_VERSION_OFFLINE}"
+fi
+
 if command -v "${POETRY_BIN}" >/dev/null 2>&1; then
-  # Poetry 2.x requer plugin de export; se falhar, faz fallback para freeze do env
+  # Em Poetry 1.8.x, o comando export depende de plugin; se indisponível, faz fallback para freeze.
   if ! "${POETRY_BIN}" export --with dev --format requirements.txt --output "${REQ_FILE}" >/dev/null 2>&1; then
     echo "Poetry export indisponível; usando freeze do ambiente virtual gerenciado pelo Poetry." >&2
-    # Garante pip atualizado dentro do env
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
-    "${POETRY_BIN}" run python - <<'PY'
-import pkgutil, subprocess, sys
-try:
-    import pip
-except Exception:
-    pass
-subprocess.check_call([sys.executable, '-m', 'pip', 'freeze'], stdout=open(sys.argv[1], 'w'))
-PY
-    "${REQ_FILE}"
+    # Gera requirements a partir do ambiente do Poetry
+    "${POETRY_BIN}" run python -m pip freeze > "${REQ_FILE}"
   else
     "${POETRY_BIN}" run python -m pip install --quiet --upgrade pip
   fi
-  "${POETRY_BIN}" run python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
-  PIP_AUDIT_CMD=("${POETRY_BIN}" "run" "pip-audit")
-  SAFETY_CMD=("${POETRY_BIN}" "run" "safety")
 else
   echo "Poetry não encontrado; utilizando ambiente global para dependências Python." >&2
-  python -m pip install --quiet --upgrade pip
-  python -m pip install --quiet "pip-audit==2.7.3" "safety==3.3.4"
-  pip freeze > "${REQ_FILE}"
-  PIP_AUDIT_CMD=("pip-audit")
-  SAFETY_CMD=("safety")
+  "${PYTHON_BIN}" -m pip install --quiet --upgrade pip
+  "${PYTHON_BIN}" -m pip freeze > "${REQ_FILE}"
 fi
 
-if [[ "${MODE}" == "all" || "${MODE}" == "pip-audit" ]]; then
+if [[ "${RUN_PIP_AUDIT}" == true ]]; then
+  PIP_AUDIT_VENV="$(create_tool_venv "pip-audit" "pip-audit==2.7.3")"
+  PIP_AUDIT_CMD=("${PIP_AUDIT_VENV}/bin/pip-audit")
+fi
+
+if [[ "${RUN_SAFETY}" == true ]]; then
+  SAFETY_VENV="$(create_tool_venv "safety" "safety==${SAFETY_PKG_VERSION}")"
+  SAFETY_CMD=("${SAFETY_VENV}/bin/safety")
+fi
+
+if [[ "${RUN_PIP_AUDIT}" == true ]]; then
   PIP_AUDIT_REPORT="${REPORT_DIR}/pip-audit.json"
-  "${PIP_AUDIT_CMD[@]}" \
-    --requirement "${REQ_FILE}" \
-    --severity HIGH \
-    --format json \
-    --output "${PIP_AUDIT_REPORT}"
+  # Executa a partir de um diretório vazio para evitar que a CLI infira project_path
+  # quando há um pyproject.toml no CWD, o que conflita com -r/--requirement em algumas versões.
+  (
+    cd "${TMP_SCAN_DIR}" >/dev/null
+    "${PIP_AUDIT_CMD[@]}" \
+      --requirement "${REQ_FILE}" \
+      --format json \
+      --output "${PIP_AUDIT_REPORT}" \
+      --progress-spinner off
+  )
   echo "Relatório do pip-audit disponível em ${PIP_AUDIT_REPORT}."
 fi
 
-if [[ "${MODE}" == "all" || "${MODE}" == "safety" ]]; then
-  SAFETY_REPORT="${REPORT_DIR}/safety.json"
-  # Desabilita telemetria do Safety para evitar ruído na saída JSON
-  export SAFETY_DISABLE_TELEMETRY=1
+if [[ "${RUN_SAFETY}" == true ]]; then
+  # Hardening do ambiente para saídas determinísticas e UTF-8
+  export PYTHONUTF8=1
+  export LANG=C
+  export LC_ALL=C
+  export CI=1
+  export PYTHONUNBUFFERED=1
+  export PYTHONIOENCODING=UTF-8
+  export SAFETY_REQUEST_TIMEOUT=${SAFETY_REQUEST_TIMEOUT:-30}
 
+  SAFETY_DIR="${REPORT_DIR}"
+  mkdir -p "${SAFETY_DIR}"
+  SAFETY_JSON_TMP="${SAFETY_DIR}/safety.json.tmp"
+  SAFETY_JSON_FINAL="${SAFETY_DIR}/safety.json"
+  SAFETY_STDERR_LOG="${SAFETY_DIR}/safety.stderr.log"
+
+  # Executa Safety em modo JSON estrito via stdout e captura stderr separado
   set +e
-  # Usa saída em arquivo via flag nativa para garantir JSON limpo
-  "${SAFETY_CMD[@]}" check --stdin --json --output "${SAFETY_REPORT}" < "${REQ_FILE}"
-  SAFETY_EXIT=$?
-  set -e
-
-  if [[ ! -s "${SAFETY_REPORT}" ]]; then
-    echo "Safety não gerou relatório JSON válido." >&2
-    exit 1
+  # Descobre suporte à flag de telemetria opcional nesta versão (best-effort)
+  SAFETY_FLAGS=()
+  if "${SAFETY_CMD[@]}" scan --help 2>/dev/null | grep -q -- '--disable-optional-telemetry'; then
+    SAFETY_FLAGS+=("--disable-optional-telemetry")
+  fi
+  SAFETY_JSON_FORMAT_FLAG=()
+  if "${SAFETY_CMD[@]}" check --help 2>/dev/null | grep -q -- '--json-output-format'; then
+    SAFETY_JSON_FORMAT_FLAG=(--json-output-format 1.1)
   fi
 
-  export SAFETY_REPORT_PATH="${SAFETY_REPORT}"
+  # Registrar versão do Safety para diagnóstico
+  { "${SAFETY_CMD[@]}" --version || true; } >>"${SAFETY_STDERR_LOG}" 2>&1
+
+  SAFETY_SUBCOMMAND="scan"
+  if [[ -z "${SAFETY_API_KEY:-}" ]]; then
+    SAFETY_SUBCOMMAND="check"
+    echo "[Safety] SAFETY_API_KEY não definido; usando fallback 'check' (offline)." >&2
+  fi
+
+  if [[ "${SAFETY_SUBCOMMAND}" == "scan" ]]; then
+    "${SAFETY_CMD[@]}" scan \
+      -r "${REQ_FILE}" \
+      --output json \
+      ${SAFETY_FLAGS[@]+"${SAFETY_FLAGS[@]}"} \
+      >"${SAFETY_JSON_TMP}" 2>"${SAFETY_STDERR_LOG}"
+  else
+    "${SAFETY_CMD[@]}" check \
+      --file "${REQ_FILE}" \
+      --output json \
+      ${SAFETY_JSON_FORMAT_FLAG[@]+"${SAFETY_JSON_FORMAT_FLAG[@]}"} \
+      >"${SAFETY_JSON_TMP}" 2>"${SAFETY_STDERR_LOG}"
+  fi
+  SAFETY_EXIT=$?
+  if [[ ${SAFETY_EXIT} -ne 0 ]]; then
+    # Alguns ambientes retornam 1 quando encontra vulnerabilidades; aceitável para processamento
+    true
+  fi
+  set -e
+
+  # Validar JSON antes de mover para o arquivo final
+  "${PYTHON_BIN}" - <<PY
+import json, sys, pathlib
+tmp = pathlib.Path(r"${SAFETY_JSON_TMP}")
+err = pathlib.Path(r"${SAFETY_STDERR_LOG}")
+raw = ''
+if tmp.exists():
+    raw = tmp.read_text(encoding='utf-8')
+
+def try_parse(text: str):
+    try:
+        json.loads(text)
+        return True
+    except Exception:
+        return False
+
+if not raw.strip():
+    print("ERRO: safety.json vazio; veja STDERR a seguir.", file=sys.stderr)
+    try:
+        est = err.read_text(encoding='utf-8')[:16000]
+    except Exception:
+        est = ''
+    if est:
+        print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+    sys.exit(1)
+
+if not try_parse(raw):
+    # Tenta saneamento: recorta a partir do primeiro '{' até o último '}'
+    start = raw.find('{')
+    end = raw.rfind('}')
+    if start != -1 and end != -1 and end > start:
+        candidate = raw[start:end+1]
+        if try_parse(candidate):
+            tmp.write_text(candidate, encoding='utf-8')
+        else:
+            print("ERRO: safety.json inválido mesmo após saneamento.", file=sys.stderr)
+            print("\n--- Amostra do stdout capturado (início) ---\n" + raw[:1000], file=sys.stderr)
+            try:
+                est = err.read_text(encoding='utf-8')[:16000]
+            except Exception:
+                est = ''
+            if est:
+                print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("ERRO: safety.json inválido: não foi encontrado bloco JSON.", file=sys.stderr)
+        print("\n--- Amostra do stdout capturado (início) ---\n" + raw[:1000], file=sys.stderr)
+        try:
+            est = err.read_text(encoding='utf-8')[:16000]
+        except Exception:
+            est = ''
+        if est:
+            print("\n--- STDERR do Safety ---\n" + est, file=sys.stderr)
+        sys.exit(1)
+PY
+  mv -f "${SAFETY_JSON_TMP}" "${SAFETY_JSON_FINAL}"
+
+  export SAFETY_REPORT_PATH="${SAFETY_JSON_FINAL}"
   export SAFETY_EXIT_CODE="${SAFETY_EXIT}"
   SAFETY_STATUS="$(
-    python <<'PY'
+    "${PYTHON_BIN}" <<'PY'
 import json
 import os
 import sys


### PR DESCRIPTION
Resumo\n- Atualiza documentação para refletir a política vigente: gates de Performance e Segurança agora são estritos em PRs (fail‑closed).\n- Registra a remoção do workflow temporário "Quick Perf+Security Check".\n- Documenta o artefato `artifacts/lighthouse/home.summary.json` usado pelo CI.\n\nArquivos\n- docs/runbooks/evidences/frontend-foundation/v1.0/README.md — nota de atualização e artefato de resumo Lighthouse.\n- docs/runbooks/frontend-foundation.md — atualização de política final de CI e artefatos.\n- docs/adr/adr-perf-front.md — addenda de atualização, mantendo ADR como histórico.\n- docs/pipelines/ci-required-checks.md — DAST em PR é fail‑closed.\n\nRollout\n- Apenas documentação. Sem alterações de código/CI.\n