### PR TITLE
ci(chromatic): Visual & A11y sempre presente; Chromatic só quando muda UI (paths-filter)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -296,7 +296,7 @@ jobs:
         working-directory: frontend
 
       - name: Executar test-runner do Storybook (axe/WCAG)
-        if: ${{ needs.changes.outputs.ui == 'true' || always() }}
+        if: ${{ needs.changes.outputs.ui == 'true' }}
         run: pnpm --filter @iabank/frontend-foundation storybook:test
 
       - name: Publicar artefatos Chromatic

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -20,6 +20,32 @@ env:
   NODE_VERSION: 20.17.0
 
 jobs:
+  changes:
+    name: Changeset (paths)
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detectar mudanças relevantes (UI/Storybook)
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            ui:
+              - 'frontend/**'
+              - 'frontend/.storybook/**'
+              - 'frontend/src/**'
+              - 'frontend/**/*.stories.*'
+              - 'frontend/scripts/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
   diag:
     name: CI Diagnostics
     runs-on: ubuntu-latest
@@ -215,7 +241,9 @@ jobs:
     name: Visual & Accessibility Gates
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' }}
-    needs: contracts
+    needs:
+      - contracts
+      - changes
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -237,36 +265,42 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resumo de mudanças (UI)
+        run: |
+          echo "UI changed? -> ${{ needs.changes.outputs.ui }}"
+
       - name: Build Storybook estático
+        if: ${{ needs.changes.outputs.ui == 'true' }}
         run: pnpm --filter @iabank/frontend-foundation storybook:build
 
       - name: Instalar navegadores Playwright (apenas Chromium)
+        if: ${{ needs.changes.outputs.ui == 'true' }}
         run: pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps chromium
 
       - name: Executar Chromatic
+        if: ${{ needs.changes.outputs.ui == 'true' && github.event_name == 'pull_request' && env.CHROMATIC_PROJECT_TOKEN != '' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-        if: ${{ github.event_name == 'pull_request' && env.CHROMATIC_PROJECT_TOKEN != '' }}
         run: |
           pnpm chromatic:ci
         working-directory: frontend
 
       - name: Validar cobertura visual por tenant (estrito ≥95%)
+        if: ${{ needs.changes.outputs.ui == 'true' && github.event_name == 'pull_request' && env.CHROMATIC_PROJECT_TOKEN != '' }}
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           CHROMATIC_MIN_COVERAGE: '95'
           CHROMATIC_TENANTS: 'tenant-alfa'
-        if: ${{ github.event_name == 'pull_request' && env.CHROMATIC_PROJECT_TOKEN != '' }}
         run: |
           pnpm chromatic:check -- --output chromatic-coverage.json
         working-directory: frontend
 
       - name: Executar test-runner do Storybook (axe/WCAG)
-        if: always()
+        if: ${{ needs.changes.outputs.ui == 'true' || always() }}
         run: pnpm --filter @iabank/frontend-foundation storybook:test
 
       - name: Publicar artefatos Chromatic
-        if: always()
+        if: ${{ always() && needs.changes.outputs.ui == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: chromatic-coverage

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -70,3 +70,16 @@ Notas de governança relacionadas:
   - O script `scripts/security/run_python_sca.sh` alterna automaticamente para `safety scan` (3.x) quando a variável está definida; sem a variável, faz fallback seguro para `safety check` (2.3.x, offline).
 - Artefatos: `artifacts/python-sca/safety.json` e `artifacts/python-sca/pip-audit.json`.
 - Política: em PRs e `main` é fail‑closed para High/Critical reportados pelo Safety; em branches não release fora de PR pode aplicar `CI_FAIL_OPEN` conforme política do workflow.
+
+## Rotação do SAFETY_API_KEY (CI)
+- Periodicidade recomendada: a cada 6 meses ou a qualquer sinal de comprometimento.
+- Procedimento de rotação (GitHub Actions → Secrets do repositório):
+  1. Gere uma nova chave no provedor do Safety (conta/console do Safety CLI).
+  2. No repositório, acesse: Settings → Secrets and variables → Actions.
+  3. Localize o secret `SAFETY_API_KEY` e clique em “Update secret”.
+  4. Substitua pelo novo valor e salve.
+  5. Valide com um PR trivial (ex.: alteração em docs) ou `workflow_dispatch` do workflow principal; o passo “Safety (Python SCA)” deve rodar com sucesso.
+  6. Revogue a chave antiga no provedor do Safety.
+- Observações:
+  - Não registre a chave em issues/PRs/logs. Evite `set -x` em scripts que imprimam variáveis.
+  - A substituição é imediata para novos jobs; jobs já em execução continuarão com o token que receberam no início da execução.


### PR DESCRIPTION
- Adiciona job `changes` (dorny/paths-filter) para detectar alterações de UI.
- Mantém o job "Visual & Accessibility Gates" sempre presente (check obrigatório), mas executa build/Chromatic/test-runner apenas quando há mudanças em UI.
- Evita travar PRs de documentação, mantendo evidência visual/a11y quando relevante.

Detalhes:
- Chromatic: continua condicional ao secret `CHROMATIC_PROJECT_TOKEN` em PR.
- Storybook test runner: roda quando há UI; em doc-only, o job finaliza rápido.

Refs: @SC-002