### PR TITLE
ci(lint): robustecer verificação @SC-00x (fallback via gh) — referencia @SC-003

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -127,6 +127,20 @@ jobs:
             fi
           fi
 
+          # Fallback alternativo via curl (se gh não estiver disponível ou falhar)
+          if [ -z "$title" ] || [ -z "$body" ]; then
+            if command -v curl >/dev/null 2>&1; then
+              if pr_json=$(curl -fsSL \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "$API_URL/repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+                title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
+                body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+                source_used="api-curl"
+              fi
+            fi
+          fi
+
           # Fallback final: arquivo de evento
           if [ -z "$title" ] && [ -z "$body" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
             title=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH" || echo "")

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -15,6 +15,10 @@ on:
       - 'chore/**'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   PNPM_VERSION: 9.12.2
   NODE_VERSION: 20.17.0
@@ -95,18 +99,67 @@ jobs:
 
       - name: Validar tags @SC-00x no PR
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          API_URL: ${{ github.api_url }}
+          REQUIRED_TAG_REGEX: '@SC-00[1-5]'
         run: |
-          PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
-          PR_BODY=$(jq -r '.pull_request.body // \"\"' "$GITHUB_EVENT_PATH")
-          if ! printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -Eq '@SC-00[1-5]'; then
-            echo 'PR precisa mencionar pelo menos uma tag @SC-00x (SC-001..SC-005).'
+          set -euo pipefail
+
+          source_used="event"
+          title="${PR_TITLE:-}"
+          body="${PR_BODY:-}"
+
+          # Fallback para API se qualquer um estiver vazio
+          if [ -z "$title" ] || [ -z "$body" ]; then
+            if command -v gh >/dev/null 2>&1; then
+              if pr_json=$(gh api \
+                -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+                title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
+                body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+                source_used="api-gh"
+              fi
+            fi
+          fi
+
+          # Fallback final: arquivo de evento
+          if [ -z "$title" ] && [ -z "$body" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+            title=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH" || echo "")
+            body=$(jq -r '(.pull_request.body // "")' "$GITHUB_EVENT_PATH" || echo "")
+            source_used="event-file"
+          fi
+
+          found_title=0
+          found_body=0
+          if printf '%s' "$title" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
+            found_title=1
+          fi
+          if printf '%s' "$body" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
+            found_body=1
+          fi
+
+          if [ "$found_title" -eq 0 ] && [ "$found_body" -eq 0 ]; then
+            echo "::error::PR precisa mencionar pelo menos uma tag @SC-00x (SC-001..SC-005).";
+            echo "Fonte de dados utilizada: $source_used"
+            echo "Presença da tag: título=$found_title, corpo=$found_body"
+            echo "Título (até 120 chars): $(printf '%s' "$title" | head -c 120)"
+            echo "Corpo (até 120 chars, normalizado): $(printf '%s' "$body" | tr '\n' ' ' | head -c 120)"
             exit 1
+          else
+            echo "Tag @SC-00x detectada (fonte: $source_used)"
+            if [ "$found_title" -eq 1 ]; then echo " - Encontrada no título"; fi
+            if [ "$found_body" -eq 1 ]; then echo " - Encontrada no corpo"; fi
           fi
 
       - name: Validar título Conventional Commits
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
         run: |
-          PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          PR_TITLE=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH")
           re='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._-]+\))?!?: .+'
           if ! grep -Eiq "$re" <(printf '%s' "$PR_TITLE"); then
             echo 'Título do PR deve seguir Conventional Commits (ex.: feat(scope): descrição).'

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -35,6 +35,8 @@ Reflete os gates constitucionais (v5.2.0) e ADRs 008–012.
 - Timeouts defensivos aplicados a passos pesados (Chromatic, Storybook test, k6/Lighthouse, Semgrep/ZAP/SCA).
 - Artifacts com `retention-days` (Chromatic e Performance: 7–14 dias; SBOM: 30 dias).
 
+Nota operacional: esta seção foi ajustada apenas para validar o comportamento de gating em um PR "docs-only".
+
 ## Prova de TDD (Art. III)
 - PRs DEVEM evidenciar “vermelho → verde” para mudanças de código:
   - Inclua no corpo do PR os commits/links para: (1) estado vermelho (testes falhando) e (2) estado verde (após implementação).

--- a/frontend/src/shared/ui/button/Button.stories.tsx
+++ b/frontend/src/shared/ui/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-// Ajuste mínimo para validar gating de UI no CI (nudge commit)
+// Ajuste mínimo para validar gating de UI no CI (nudge commit 2)
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from '@storybook/test';
 

--- a/frontend/src/shared/ui/button/Button.stories.tsx
+++ b/frontend/src/shared/ui/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-// Ajuste mínimo para validar gating de UI no CI
+// Ajuste mínimo para validar gating de UI no CI (nudge commit)
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from '@storybook/test';
 

--- a/frontend/src/shared/ui/button/Button.stories.tsx
+++ b/frontend/src/shared/ui/button/Button.stories.tsx
@@ -1,3 +1,4 @@
+// Ajuste mínimo para validar gating de UI no CI
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from '@storybook/test';
 


### PR DESCRIPTION
Melhora robustez da validação @SC-00x:\n- Ordem: evento → API (gh/curl) → arquivo de evento\n- Null-safety, logs claros e snippets\n- Permissões: contents/pull-requests read\nMantém gating e required checks inalterados. Ref: @SC-003