### PR TITLE
docs: validação de gates (docs-only) @SC-003

### DIFF
--- a/docs/ci-gates-validation.md
+++ b/docs/ci-gates-validation.md
@@ -1,0 +1,5 @@
+# Validação de gates (docs-only)
+
+Este PR existe apenas para validar que gates pesados (Visual & A11y, Performance) são pulados quando só há mudanças de documentação.
+
+Ref: @SC-003


### PR DESCRIPTION
PR de documentação para validar comportamento dos gates em docs-only.\n\nEsperado:\n- Jobs aparecem como required, mas steps pesados de UI/Performance são pulados (skip).\n- Lint/Test/Contracts/Security apenas conforme gating por paths.\n\nRef: @SC-003