### PR TITLE
docs: template de PR (Conventional + @SC-00x)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,16 @@
 ## Descrição
-Explique brevemente a mudança e o porquê.
 
-## Evidências de TDD (Art. III)
-- [ ] Link/commit do estado VERMELHO (testes falhando): <!-- cole o commit/URL -->
-- [ ] Link/commit do estado VERDE (após implementação): <!-- cole o commit/URL -->
-- [ ] Caso de exceção (infra/CI/docs): <!-- justifique aqui, se aplicável -->
-
-## Gates de Qualidade
-- [ ] Cobertura (backend ≥ 85%) confirmada
-- [ ] Complexidade Radon (cc ≤ 10) confirmada
-- [ ] Chromatic coverage ≥ 95% por tenant (quando aplicável)
-- [ ] Lighthouse budgets aprovados (quando aplicável)
-- [ ] Contracts OK (Spectral + openapi-diff + Pact)
+Explique resumidamente o que este PR faz e por quê.
 
 ## Checklist
-- [ ] Sem mudanças de stack/arquitetura fora do Blueprint
-- [ ] Sem PII em logs/URLs; CSP/Trusted Types ok
-- [ ] Docs atualizadas (se necessário)
+
+- [ ] Título segue Conventional Commits (ex.: `feat(scope): descrição`).
+- [ ] Inclui pelo menos uma tag `@SC-00x` (SC-001..SC-005) no título ou corpo, quando aplicável.
+- [ ] Não é PR isento de tag (@SC-00x) por prefixo (`chore/`, `ci/`, `docs/`, `tests/`) — ou marcar N/A.
+- [ ] Se impacta UI, está ciente de que gates Visuais/A11y e Performance irão rodar.
+- [ ] Se é "docs-only", confirmado que não há mudanças fora de `docs/**` e metadados.
+
+## Contexto / Referências
+
+- Relaciona @SC-00x: 
+- Issues relacionadas: 

--- a/docs/ci-gates-validation.md
+++ b/docs/ci-gates-validation.md
@@ -1,0 +1,5 @@
+# Validação de gates (docs-only)
+
+Este PR existe apenas para validar que gates pesados (Visual & A11y, Performance) são pulados quando só há mudanças de documentação.
+
+Ref: @SC-003


### PR DESCRIPTION
Adiciona template de PR com checklist para reduzir falhas nos gates e reforçar a política de @SC-00x e Conventional Commits.