### PR TITLE
ci: exigir template de PR e padronizar fallback no Conventional

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -97,6 +97,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verificar uso do template de PR
+        if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          API_URL: ${{ github.api_url }}
+        run: |
+          bash scripts/ci/check-pr-template.sh
+
       - name: Validar tags @SC-00x no PR
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
         env:
@@ -108,75 +119,45 @@ jobs:
           API_URL: ${{ github.api_url }}
           REQUIRED_TAG_REGEX: '@SC-00[1-5]'
         run: |
+          bash scripts/ci/validate-sc-tag.sh
+
+      - name: Validar título Conventional Commits
+        if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          API_URL: ${{ github.api_url }}
+        run: |
           set -euo pipefail
-
-          source_used="event"
           title="${PR_TITLE:-}"
-          body="${PR_BODY:-}"
-
-          # Fallback para API se qualquer um estiver vazio
-          if [ -z "$title" ] || [ -z "$body" ]; then
+          source_used="event"
+          if [ -z "$title" ]; then
             if command -v gh >/dev/null 2>&1; then
-              if pr_json=$(gh api \
-                -H "Accept: application/vnd.github+json" \
-                "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+              if pr_json=$(gh api -H "Accept: application/vnd.github+json" "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
                 title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
-                body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
                 source_used="api-gh"
               fi
             fi
           fi
-
-          # Fallback alternativo via curl (se gh não estiver disponível ou falhar)
-          if [ -z "$title" ] || [ -z "$body" ]; then
+          if [ -z "$title" ]; then
             if command -v curl >/dev/null 2>&1; then
-              if pr_json=$(curl -fsSL \
-                -H "Authorization: Bearer $GH_TOKEN" \
-                -H "Accept: application/vnd.github+json" \
-                "$API_URL/repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+              if pr_json=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$API_URL/repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
                 title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
-                body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
                 source_used="api-curl"
               fi
             fi
           fi
-
-          # Fallback final: arquivo de evento
-          if [ -z "$title" ] && [ -z "$body" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+          if [ -z "$title" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
             title=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH" || echo "")
-            body=$(jq -r '(.pull_request.body // "")' "$GITHUB_EVENT_PATH" || echo "")
             source_used="event-file"
           fi
-
-          found_title=0
-          found_body=0
-          if printf '%s' "$title" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
-            found_title=1
-          fi
-          if printf '%s' "$body" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
-            found_body=1
-          fi
-
-          if [ "$found_title" -eq 0 ] && [ "$found_body" -eq 0 ]; then
-            echo "::error::PR precisa mencionar pelo menos uma tag @SC-00x (SC-001..SC-005).";
-            echo "Fonte de dados utilizada: $source_used"
-            echo "Presença da tag: título=$found_title, corpo=$found_body"
-            echo "Título (até 120 chars): $(printf '%s' "$title" | head -c 120)"
-            echo "Corpo (até 120 chars, normalizado): $(printf '%s' "$body" | tr '\n' ' ' | head -c 120)"
-            exit 1
-          else
-            echo "Tag @SC-00x detectada (fonte: $source_used)"
-            if [ "$found_title" -eq 1 ]; then echo " - Encontrada no título"; fi
-            if [ "$found_body" -eq 1 ]; then echo " - Encontrada no corpo"; fi
-          fi
-
-      - name: Validar título Conventional Commits
-        if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
-        run: |
-          PR_TITLE=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH")
           re='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._-]+\))?!?: .+'
-          if ! grep -Eiq "$re" <(printf '%s' "$PR_TITLE"); then
-            echo 'Título do PR deve seguir Conventional Commits (ex.: feat(scope): descrição).'
+          if ! printf '%s' "$title" | grep -Eiq "$re"; then
+            echo "::error::Título do PR deve seguir Conventional Commits (ex.: feat(scope): descrição)."
+            echo "Fonte de dados utilizada: $source_used"
+            echo "Título (até 120 chars): $(printf '%s' "$title" | head -c 120)"
             exit 1
           fi
 

--- a/scripts/ci/check-pr-template.sh
+++ b/scripts/ci/check-pr-template.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifica se o corpo do PR aparenta usar o template (marca "## Checklist" ou frase da checklist).
+# Entrada via env: PR_BODY (opcional), PR_NUMBER, REPO, GH_TOKEN, API_URL, GITHUB_EVENT_PATH
+
+marker_regex='(^|\n)##[[:space:]]*Checklist|inclui[[:space:]]+pelo[[:space:]]+menos[[:space:]]+uma[[:space:]]+tag[[:space:]]+@SC-00x'
+
+source_used="event"
+body="${PR_BODY:-}"
+
+if [ -z "$body" ]; then
+  if command -v gh >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ] && [ -n "${REPO:-}" ]; then
+    if pr_json=$(gh api -H "Accept: application/vnd.github+json" "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+      body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+      source_used="api-gh"
+    fi
+  fi
+fi
+
+if [ -z "$body" ]; then
+  if command -v curl >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ] && [ -n "${REPO:-}" ] && [ -n "${GH_TOKEN:-}" ] && [ -n "${API_URL:-}" ]; then
+    if pr_json=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$API_URL/repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+      body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+      source_used="api-curl"
+    fi
+  fi
+fi
+
+if [ -z "$body" ] && [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+  body=$(jq -r '(.pull_request.body // "")' "$GITHUB_EVENT_PATH" || echo "")
+  source_used="event-file"
+fi
+
+if printf '%s' "$body" | tr '\r' '\n' | grep -Eiq "$marker_regex"; then
+  echo "Template de PR aparente detectado (fonte: $source_used)"
+else
+  echo "::error::Utilize o template de PR (inclua a seção \"## Checklist\")." \
+       "O template reduz falhas no gate @SC-00x."
+  echo "Fonte de dados utilizada: $source_used"
+  echo "Corpo (até 120 chars): $(printf '%s' "$body" | tr '\n' ' ' | head -c 120)"
+  exit 1
+fi
+

--- a/scripts/ci/validate-sc-tag.sh
+++ b/scripts/ci/validate-sc-tag.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Entrada via env:
+# - PR_TITLE, PR_BODY (opcional, do contexto do evento)
+# - PR_NUMBER, REPO, GH_TOKEN, API_URL (para fallback API)
+# - REQUIRED_TAG_REGEX (regex da tag), default '@SC-00[1-5]'
+# - GITHUB_EVENT_PATH (fallback final)
+
+REQUIRED_TAG_REGEX="${REQUIRED_TAG_REGEX:-@SC-00[1-5]}"
+
+source_used="event"
+title="${PR_TITLE:-}"
+body="${PR_BODY:-}"
+
+# Fallback: API via gh
+if [ -z "$title" ] || [ -z "$body" ]; then
+  if command -v gh >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ] && [ -n "${REPO:-}" ]; then
+    if pr_json=$(gh api -H "Accept: application/vnd.github+json" "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+      title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
+      body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+      source_used="api-gh"
+    fi
+  fi
+fi
+
+# Fallback alternativo: API via curl
+if [ -z "$title" ] || [ -z "$body" ]; then
+  if command -v curl >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ] && [ -n "${REPO:-}" ] && [ -n "${GH_TOKEN:-}" ] && [ -n "${API_URL:-}" ]; then
+    if pr_json=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "$API_URL/repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null); then
+      title=$(printf '%s' "$pr_json" | jq -r '(.title // "")')
+      body=$(printf '%s' "$pr_json" | jq -r '(.body // "")')
+      source_used="api-curl"
+    fi
+  fi
+fi
+
+# Fallback final: arquivo de evento
+if [ -z "$title" ] && [ -z "$body" ] && [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "$GITHUB_EVENT_PATH" ]; then
+  title=$(jq -r '(.pull_request.title // "")' "$GITHUB_EVENT_PATH" || echo "")
+  body=$(jq -r '(.pull_request.body // "")' "$GITHUB_EVENT_PATH" || echo "")
+  source_used="event-file"
+fi
+
+found_title=0
+found_body=0
+if printf '%s' "$title" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
+  found_title=1
+fi
+if printf '%s' "$body" | grep -Eq "${REQUIRED_TAG_REGEX}"; then
+  found_body=1
+fi
+
+if [ "$found_title" -eq 0 ] && [ "$found_body" -eq 0 ]; then
+  echo "::error::PR precisa mencionar pelo menos uma tag @SC-00x (SC-001..SC-005)."
+  echo "Fonte de dados utilizada: $source_used"
+  echo "Presença da tag: título=$found_title, corpo=$found_body"
+  echo "Título (até 120 chars): $(printf '%s' "$title" | head -c 120)"
+  echo "Corpo (até 120 chars, normalizado): $(printf '%s' "$body" | tr '\n' ' ' | head -c 120)"
+  exit 1
+else
+  echo "Tag @SC-00x detectada (fonte: $source_used)"
+  if [ "$found_title" -eq 1 ]; then echo " - Encontrada no título"; fi
+  if [ "$found_body" -eq 1 ]; then echo " - Encontrada no corpo"; fi
+fi
+


### PR DESCRIPTION
- Exige uso do template de PR (gating aplicado a PRs não-isentos)\n- Padroniza fallback do título (Conventional Commits) com API (gh/curl)\n- Extrai validação @SC-00x para scripts/ci/validate-sc-tag.sh\n\nMantém nomes de jobs/steps (required checks inalterados).