### PR TITLE
chore(gitignore): ignorar artefatos temporários do gh/ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@ codex-action/
 .terraform/
 *.tfstate
 *.tfstate.backup
+
+# CLI/CI: artefatos temporários locais (não versionar)
+.gh_*.json
+.runs_*.json
+.run_*.json
+.vault_*.json
+.pr_release_test.json
+.cache/
+.tmp/


### PR DESCRIPTION
Adiciona padrões para evitar versionamento de artefatos temporários gerados por consultas locais do gh CLI e inspeções do CI.

Padrões:
- .gh_*.json
- .runs_*.json
- .run_*.json
- .vault_*.json
- .pr_release_test.json
- .cache/
- .tmp/

Impacto: mantém o repo limpo de arquivos transitórios gerados em investigações locais.