### PR TITLE
ci(workflows): padroniza uso de github.token em workflows

### DIFF
--- a/.github/workflows/ci-outage-selftest.yml
+++ b/.github/workflows/ci-outage-selftest.yml
@@ -51,7 +51,7 @@ jobs:
           # Force non-release branch name to validate fail-open behavior (we also pass explicit JSON)
           GITHUB_REF_NAME: selftest-failopen
           # GitHub context (best effort; script tolerates missing PR)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           echo "Running outage selftest (fail-open)..."

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -48,7 +48,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           filters: |
             ui:
               - 'frontend/**'
@@ -763,7 +763,7 @@ jobs:
 
       - name: Executar política de outage
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_OUTAGE_CHROMATIC_JOB_STATUS: ${{ needs.visual-accessibility.result }}
           CI_OUTAGE_CHROMATIC_JOB_NAME: visual-accessibility

--- a/documentacao_oficial_spec-kit/.github/workflows/release.yml
+++ b/documentacao_oficial_spec-kit/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Get latest tag
         id: get_tag
         run: |
@@ -33,7 +33,7 @@ jobs:
           chmod +x .github/workflows/scripts/check-release-exists.sh
           .github/workflows/scripts/check-release-exists.sh ${{ steps.get_tag.outputs.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Create release package variants
         if: steps.check_release.outputs.exists == 'false'
         run: |
@@ -51,10 +51,9 @@ jobs:
           chmod +x .github/workflows/scripts/create-github-release.sh
           .github/workflows/scripts/create-github-release.sh ${{ steps.get_tag.outputs.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Update version in pyproject.toml (for release artifacts only)
         if: steps.check_release.outputs.exists == 'false'
         run: |
           chmod +x .github/workflows/scripts/update-version.sh
           .github/workflows/scripts/update-version.sh ${{ steps.get_tag.outputs.new_version }}
-


### PR DESCRIPTION
Este PR padroniza o uso do token do GitHub em nossos workflows.

Mudanças:
- Substitui secrets.GITHUB_TOKEN por `${{ github.token }}` onde aplicável.
- Mantém variáveis de ambiente GH_TOKEN/GITHUB_TOKEN quando necessárias, agora alimentadas por `${{ github.token }}`.

Motivação:
- Alinha com boas práticas do GitHub Actions e evita confusão entre contextos de token.

Impacto:
- Sem mudança funcional esperada. Apenas padronização.

Closes #68
