### PR TITLE
ci(contracts): migrar workflow para pnpm + cache Node 20

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -7,8 +7,12 @@ on:
       - '.github/workflows/ci-contracts.yml'
       - 'scripts/api/check_rate_headers.sh'
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
   workflow_dispatch:
+
+env:
+  PNPM_VERSION: 9.12.2
+  NODE_VERSION: 20.17.0
 
 jobs:
   validate-contracts:
@@ -17,42 +21,53 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies (Node)
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies (pnpm)
         if: ${{ hashFiles('package.json') != '' }}
-        run: |
-          npm install
+        run: pnpm install --frozen-lockfile
         shell: bash
 
       - name: Spectral lint (skips if not installed)
         run: |
-          if command -v npx >/dev/null 2>&1; then
+          if command -v pnpm >/dev/null 2>&1; then
             if [ -n "$(ls contracts 2>/dev/null)" ]; then
-              npx --yes @stoplight/spectral@6 lint contracts/**/*.yaml || exit 1
+              pnpm dlx @stoplight/spectral@6 lint contracts/**/*.yaml || exit 1
             else
               echo "::warning::No contracts directory to lint"
             fi
           else
-            echo "::warning::npx not available; skipping Spectral lint"
+            echo "::warning::pnpm not available; skipping Spectral lint"
           fi
         shell: bash
 
       - name: OpenAPI diff guard
         run: |
-          if command -v npx >/dev/null 2>&1; then
+          if command -v pnpm >/dev/null 2>&1; then
             if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-              npx --yes openapi-diff contracts/api.previous.yaml contracts/api.yaml
+              pnpm dlx openapi-diff contracts/api.previous.yaml contracts/api.yaml
             else
               echo "::warning::OpenAPI baseline missing; skipping diff"
             fi
           else
-            echo "::warning::npx not available; skipping openapi-diff"
+            echo "::warning::pnpm not available; skipping openapi-diff"
           fi
         shell: bash
 
       - name: Pact contract tests
         run: |
-          if command -v npm >/dev/null 2>&1 && npm run | grep -q 'test:pact'; then
-            npm run test:pact
+          if command -v pnpm >/dev/null 2>&1 && pnpm run | grep -q 'test:pact'; then
+            pnpm run test:pact
           else
             echo "::warning::No pact test command defined; skipping"
           fi

--- a/.github/workflows/ci-outage-selftest.yml
+++ b/.github/workflows/ci-outage-selftest.yml
@@ -51,7 +51,7 @@ jobs:
           # Force non-release branch name to validate fail-open behavior (we also pass explicit JSON)
           GITHUB_REF_NAME: selftest-failopen
           # GitHub context (best effort; script tolerates missing PR)
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           echo "Running outage selftest (fail-open)..."

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -48,7 +48,7 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           filters: |
             ui:
               - 'frontend/**'
@@ -763,7 +763,7 @@ jobs:
 
       - name: Executar política de outage
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_OUTAGE_CHROMATIC_JOB_STATUS: ${{ needs.visual-accessibility.result }}
           CI_OUTAGE_CHROMATIC_JOB_NAME: visual-accessibility

--- a/documentacao_oficial_spec-kit/.github/workflows/release.yml
+++ b/documentacao_oficial_spec-kit/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Get latest tag
         id: get_tag
         run: |
@@ -33,7 +33,7 @@ jobs:
           chmod +x .github/workflows/scripts/check-release-exists.sh
           .github/workflows/scripts/check-release-exists.sh ${{ steps.get_tag.outputs.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Create release package variants
         if: steps.check_release.outputs.exists == 'false'
         run: |
@@ -51,10 +51,9 @@ jobs:
           chmod +x .github/workflows/scripts/create-github-release.sh
           .github/workflows/scripts/create-github-release.sh ${{ steps.get_tag.outputs.new_version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Update version in pyproject.toml (for release artifacts only)
         if: steps.check_release.outputs.exists == 'false'
         run: |
           chmod +x .github/workflows/scripts/update-version.sh
           .github/workflows/scripts/update-version.sh ${{ steps.get_tag.outputs.new_version }}
-


### PR DESCRIPTION
Migração do CI de contratos para pnpm, alinhando com o restante do projeto.\n\nMudanças:\n- Setup pnpm (@ v9.12.2) e Node 20.17.0.\n- Cache de dependências via actions/setup-node (cache: pnpm).\n- Troca npm/npx por pnpm install e pnpm dlx (Spectral e openapi-diff).\n- Triggers atualizados para usar pnpm-lock.yaml.\n\nBenefícios:\n- Builds mais rápidos e consistentes com a base.\n- Menos inconsistência entre pipelines.\n\nCloses #70