### PR TITLE
ci(test): smoke de anotações de PR via GITHUB_TOKEN (temporário)

### DIFF
--- a/.github/workflows/ci-smoke-pr-annotations.yml
+++ b/.github/workflows/ci-smoke-pr-annotations.yml
@@ -1,0 +1,66 @@
+name: PR Annotations Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Número do PR a anotar"
+        required: true
+        default: "90"
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  smoke:
+    name: Testa comentário e label no PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Postar comentário e (opcionalmente) label, depois limpar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          echo "Repo: $REPO | PR: #$PR_NUMBER"
+
+          header_auth=("-H" "Authorization: Bearer $GITHUB_TOKEN" "-H" "Accept: application/vnd.github+json")
+
+          echo "== Criando comentário no PR =="
+          comment_body="Smoke test: GITHUB_TOKEN pode anotar PR (será removido). Run: $RUN_URL"
+          payload=$(jq -n --arg body "$comment_body" '{body:$body}')
+          resp=$(curl -sS -X POST "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments" "${header_auth[@]}" -d "$payload")
+          comment_id=$(jq -r '.id // empty' <<<"$resp")
+          if [ -z "${comment_id:-}" ]; then
+            echo "Falha ao criar comentário: $resp" >&2
+            exit 1
+          fi
+          echo "Comentário criado, id=$comment_id"
+
+          echo "== (Opcional) Adicionando label ao PR =="
+          label_name="ci-smoke-annotations"
+          # Verifica se a label existe; se não, cria
+          if ! curl -fsS "https://api.github.com/repos/$REPO/labels/$label_name" "${header_auth[@]}" >/dev/null; then
+            echo "Label '$label_name' não existe; criando..."
+            create_label_payload=$(jq -n --arg name "$label_name" --arg color "cfd3d7" --arg description "Label temporária do smoke test" '{name:$name,color:$color,description:$description}')
+            curl -sS -X POST "https://api.github.com/repos/$REPO/labels" "${header_auth[@]}" -d "$create_label_payload" >/dev/null || echo "Aviso: falhou ao criar label (prosseguindo sem label)"
+          fi
+          # Tenta adicionar label ao PR; ignora falha
+          add_labels_payload=$(jq -n --argjson labels "[\"$label_name\"]" '{labels:$labels}')
+          curl -sS -X POST "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels" "${header_auth[@]}" -d "$add_labels_payload" >/dev/null || echo "Aviso: falhou ao adicionar label (ok)"
+          echo "Label '$label_name' adicionada (se possível)."
+
+          echo "== Limpando (removendo label e comentário) =="
+          # Remove label do PR (se presente)
+          curl -sS -X DELETE "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/$label_name" "${header_auth[@]}" >/dev/null || true
+          # Remove comentário
+          curl -sS -X DELETE "https://api.github.com/repos/$REPO/issues/comments/$comment_id" "${header_auth[@]}" >/dev/null || true
+          echo "OK: comentário criado e removido com sucesso."


### PR DESCRIPTION
Adiciona workflow `ci-smoke-pr-annotations.yml` (workflow_dispatch) para validar, de forma controlada, a capacidade do GITHUB_TOKEN de:
- criar comentário em PR
- adicionar/remover label no PR

O job cria e em seguida remove o comentário e a label, evitando ruído. Após a verificação, abriremos PR para remover este workflow.

Escopos solicitados no arquivo:
- contents: read
- pull-requests: write
- issues: write