### PR TITLE
docs(ci): validar gates e registrar permissões do Outage Guard

### DIFF
--- a/docs/ci-gates-validation.md
+++ b/docs/ci-gates-validation.md
@@ -1,0 +1,31 @@
+# Validação dos Gates de CI — Anotações de PR pelo Outage Guard (NFR-008)
+
+Contexto
+- Issue #82: permitir anotar PRs (labels/comentários) a partir do Outage Guard.
+- PR #90 aplicou `permissions` no workflow principal para habilitar escrita em PRs.
+
+Permissões exigidas (GITHUB_TOKEN)
+- No workflow `.github/workflows/frontend-foundation.yml`, garantir:
+  - `permissions:`
+    - `contents: read`
+    - `pull-requests: write`
+    - `issues: write`
+
+Como validamos (smoke test)
+- Adicionamos um workflow temporário `ci-smoke-pr-annotations.yml` (workflow_dispatch) para postar um comentário e aplicar/remover uma label em um PR existente, usando `GITHUB_TOKEN`.
+- Executamos na branch `main` com `pr_number=90`.
+- Logs do run confirmaram:
+  - comentário criado e removido com sucesso;
+  - label temporária adicionada e removida com sucesso.
+
+Evidências
+- PR de permissão: PR #90 — “ci(outage): permissões para anotar PRs (#82)”.
+- Run de smoke na main: Actions run `PR Annotations Smoke Test` (success) — URL: ver histórico de Actions em `main` na data 2025‑11‑09 (run `19215914570`).
+- Limpeza do workflow/label de teste:
+  - PR #95 — remove `ci-smoke-pr-annotations.yml` (mergeado).
+  - Label `ci-smoke-annotations` removida do repositório.
+
+Operação
+- O Outage Guard (job `ci-outage-guard`) só anotará PRs quando detectar outage; em runs normais (`outages: []`), nada será escrito.
+- Em caso de ajuste futuro, repetir o smoke test acima para garantir o caminho de escrita.
+

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -63,6 +63,13 @@ Estes são os contextos atualmente exigidos na proteção da branch `main` (Bran
 - CI Outage Guard
 - CI Diagnostics
 
+Nota — CI Outage Guard (permissões para anotar PR)
+- Para que o Outage Guard possa rotular/comentar PRs quando houver outage, o workflow principal precisa do bloco `permissions` com:
+  - `contents: read`
+  - `pull-requests: write`
+  - `issues: write`
+- Este requisito foi aplicado no PR #90 e verificado em 2025‑11‑09 via smoke test (comentário/label criados e removidos com sucesso em PR existente).
+
 Notas de governança relacionadas:
 - Merge: squash-only, com exclusão de branch ao mesclar.
 - Histórico linear: habilitado.

--- a/docs/runbooks/frontend-outage.md
+++ b/docs/runbooks/frontend-outage.md
@@ -18,6 +18,14 @@ Componentes relevantes:
 - Secrets no GitHub: `FOUNDATION_OTEL_OUTAGE_ENDPOINT`, `FOUNDATION_OTEL_OUTAGE_TOKEN`.
 - Worker Cloudflare: binding `CI_OUTAGES` (KV Namespace) + secret `CI_OUTAGE_TOKEN`.
 
+Permissões do workflow (GITHUB_TOKEN)
+- Para anotar PRs (labels/comentários) quando houver outage, o workflow principal DEVE declarar:
+  - `permissions:`
+    - `contents: read`
+    - `pull-requests: write`
+    - `issues: write`
+- Evidência (2025‑11‑09): run `Frontend Foundation CI` no PR #90 exibiu no log do job `CI Outage Guard` o bloco “GITHUB_TOKEN Permissions: Contents: read; Issues: write; PullRequests: write”.
+
 ## Pré‑requisitos
 
 - Repositório com os secrets configurados (GitHub → Settings → Secrets and variables → Actions):
@@ -62,6 +70,10 @@ Observações:
   - Mantenha o rótulo `ci-outage` até a normalização.
   - Evite merge sem revisão consciente do risco (principalmente se o PR impactar diretamente os gates afetados).
   - Quando os jobs passarem verde novamente, remova o rótulo e prossiga.
+
+## Evidências complementares (2025‑11‑09)
+- PR #90 aplicou as permissões no workflow de CI para permitir anotações em PRs.
+- Smoke test: workflow temporário executado na `main` (run `19215914570`) criou e removeu comentário e label em PR, comprovando o caminho de escrita do `GITHUB_TOKEN`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adiciona/atualiza documentação:
- docs/ci-gates-validation.md (procedimento e evidências do smoke)
- docs/runbooks/frontend-outage.md (permissões do GITHUB_TOKEN + evidências)
- docs/pipelines/ci-required-checks.md (nota sobre permissões para anotação de PR)

Evidências:
- PR #90 (permissões aplicadas)
- Run de smoke na main (2025-11-09, id 19215914570)
- PRs #93/#95 (criação e remoção do workflow de smoke)