### PR TITLE
ci: alinhar Poetry (1.8.3) e remover poetry lock no CI (#83)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -277,11 +277,8 @@ jobs:
       # Removido: plugin de export não é necessário para instalação/execução dos testes
       # e versões recentes (>=1.9) exigem Poetry 2.x, conflitando com 1.8.x.
 
-      - name: Atualizar lock (sem atualizar versões)
-        run: poetry lock --no-update
-
       - name: Install Python dependencies
-        run: poetry install --with dev
+        run: poetry install --with dev --no-ansi --no-interaction
 
       - name: Pytest (coverage gate)
         env:
@@ -617,13 +614,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry==1.8.3
 
-      - name: Atualizar lock (sem atualizar versões)
-        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
-        run: poetry lock --no-update
-
       - name: Install Python dependencies
         if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
-        run: poetry install --with dev
+        run: poetry install --with dev --no-ansi --no-interaction
 
       - name: Aguardar Postgres ficar disponível
         if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim-bookworm
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     POETRY_HOME=/opt/poetry \
-    POETRY_VERSION=2.2.1 \
+    POETRY_VERSION=1.8.3 \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     PATH="/opt/poetry/bin:${PATH}"
 
@@ -16,7 +16,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 WORKDIR /app
 
 COPY pyproject.toml poetry.lock* /app/
-RUN poetry install --with dev --no-root
+RUN poetry install --with dev --no-ansi --no-interaction --no-root
 
 COPY backend /app/backend
 COPY contracts /app/contracts


### PR DESCRIPTION
Unifica versão para 1.8.3 (Docker/CI) e instala com --no-ansi --no-interaction; remove passo de 'poetry lock' no CI.