### PR TITLE
ci(perf): selftest timeout budgets com sleep controlado (#85)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -490,7 +490,9 @@ jobs:
         timeout-minutes: 15
         env:
           LIGHTHOUSE_TARGET_URL: http://localhost:4173/foundation/scaffold?tenant=tenant-alfa&feature=foundation-scaffold
-        run: pnpm perf:lighthouse
+        run: |
+          sleep ${VALIDATE_85_SLEEP:-901}
+          pnpm perf:lighthouse
 
       - name: Verificar artefatos Lighthouse
         if: ${{ always() && needs.changes.outputs.ui == 'true' }}

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -9,6 +9,7 @@ on:
       - 'release/**'
   push:
     branches:
+      - 'validate/**'
       - main
       - develop
       - 'feature/**'

--- a/docs/ci-validation/trigger-85.md
+++ b/docs/ci-validation/trigger-85.md
@@ -1,0 +1,1 @@
+trigger 85


### PR DESCRIPTION
## Checklist

- [x] Inclui pelo menos uma tag @SC-00x: @SC-001
- [x] Escopo de validação controlado (canário)
- [x] Evidências serão coletadas via Step Summary e artifacts

Contexto: PR canário para validação de CI. Após coleta de evidências, será revertido/fechado.