### PR TITLE
ci: corrigir YAML (Resumo ZAP) para destravar workflow e validar Poetry (#83)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -661,7 +661,8 @@ jobs:
 
       - name: Resumo ZAP
         if: always()
-        run: echo -e "DAST outcome: ${{ steps.security_dast.outcome }}\nArtifacts: artifacts/zap" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          echo -e "DAST outcome: ${{ steps.security_dast.outcome }}\nArtifacts: artifacts/zap" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validação pgcrypto
         id: security_pgcrypto

--- a/temp_issue/issue-83-status.md
+++ b/temp_issue/issue-83-status.md
@@ -60,3 +60,4 @@ Objetivo: comprovar que (1) CI e Docker estão alinhados na versão do Poetry (1
 - Adicionar step de verificação de versão: `poetry --version | grep 1.8.3`.
 - Falhar o job se o lock for modificado: `git diff --exit-code poetry.lock` após a instalação.
 
+\n<!-- CI validation trigger: 2025-11-10T19:23:13Z -->


### PR DESCRIPTION
Este PR corrige um erro de parsing no workflow (`Resumo ZAP`), que estava impedindo execuções, e valida na prática o alinhamento do Poetry solicitado na issue #83.

Evidências
- Run bem-sucedido: https://github.com/Tomvaz11/iabank/actions/runs/19243783235
- Poetry instalado no CI: 1.8.3 (instalado via `pip install poetry==1.8.3`)
- Instalação Python no CI: `poetry install --with dev --no-ansi --no-interaction` (sem `poetry lock`).

Validação
- Jobs de lint/test/pytest/radon passaram no branch de validação.

Após merge, os pushes/PRs futuros deixarão de falhar no início por erro de YAML e manterão o alinhamento de Poetry em 1.8.3 conforme a #83.
