### PR TITLE
ci(security): validação issue #84 — SAST timeout curto (SEMGREP_TIMEOUT=5)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -550,7 +550,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      CI_ENFORCE_FULL_SECURITY: ${{ github.event_name != 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/')) }}
+      # Força execução completa dos checks de segurança nesta validação (issue #84)
+      CI_ENFORCE_FULL_SECURITY: true
       CI_FAIL_OPEN: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/') }}
       FOUNDATION_DB_VENDOR: postgresql
       FOUNDATION_DB_HOST: 127.0.0.1

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -559,8 +559,7 @@ jobs:
       FOUNDATION_DB_NAME: foundation
       FOUNDATION_DB_USER: foundation
       FOUNDATION_DB_PASSWORD: foundation
-      # Validação issue #84: forçar timeout curto do Semgrep para confirmar que o job não pendura
-      SEMGREP_TIMEOUT: '5'
+      # Validação issue #84: removido SEMGREP_TIMEOUT para validar fallback padrão (300s)
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -558,6 +558,8 @@ jobs:
       FOUNDATION_DB_NAME: foundation
       FOUNDATION_DB_USER: foundation
       FOUNDATION_DB_PASSWORD: foundation
+      # Validação issue #84: forçar timeout curto do Semgrep para confirmar que o job não pendura
+      SEMGREP_TIMEOUT: '5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Validação prática da issue #84: força timeout do Semgrep para 5s e confirma que o job não pendura. Após este run, faremos commit removendo a variável para validar o fallback (300s).