### PR TITLE
ci(security): ZAP artifacts — garantir relatórios e coletar logs (#85)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -665,6 +665,14 @@ jobs:
         timeout-minutes: 12
         run: poetry run bash scripts/security/run_dast.sh
 
+      - name: Coletar logs do Django (ZAP)
+        if: always()
+        run: |
+          mkdir -p artifacts/zap
+          if [ -f /tmp/django-zap.log ]; then
+            cp /tmp/django-zap.log artifacts/zap/django-zap.log || true
+          fi
+
       - name: Upload ZAP artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/security/run_dast.sh
+++ b/scripts/security/run_dast.sh
@@ -55,6 +55,8 @@ set +e
 docker run --rm \
   --pull=always \
   --network=host \
+  -u 0:0 \
+  -w /zap/wrk \
   -v "${REPORT_DIR}:/zap/wrk" \
   ghcr.io/zaproxy/zaproxy:stable \
   /zap/zap-baseline.py \
@@ -64,13 +66,15 @@ docker run --rm \
   -w zap-warnings.md \
   -r zap-report.html \
   -x zap-report.xml \
-  -m 5
+  -m 5 ${ZAP_BASELINE_EXTRA_ARGS:-}
 status=$?
 set -e
 if [ "$status" -eq 2 ]; then
   echo "[DAST] Somente WARN foram detectados — registrando como sucesso (sem FAILs)."
   status=0
 fi
+echo "Conteúdo do diretório de relatórios (${REPORT_DIR}):"
+ls -la "${REPORT_DIR}" || true
 exit "$status"
 
 echo "Relatórios ZAP armazenados em ${REPORT_DIR}."


### PR DESCRIPTION
## Descrição

Melhoria operacional para a Issue #85: garantir a geração e publicação dos artefatos do ZAP (relatórios + logs) no CI.

- `scripts/security/run_dast.sh`:
  - Monta `artifacts/zap` como workdir do container (`-w /zap/wrk`) e executa como root (`-u 0:0`) para evitar erros de permissão ao gerar relatórios.
  - Aceita `ZAP_BASELINE_EXTRA_ARGS` para diagnósticos.
  - Lista o conteúdo do diretório de relatórios ao final, facilitando troubleshooting.
- Workflow `.github/workflows/frontend-foundation.yml`:
  - Adiciona step "Coletar logs do Django (ZAP)" (sempre) para incluir `/tmp/django-zap.log` nos artifacts `zap-reports`.

## Checklist
- [x] Título segue Conventional Commits.
- [x] Inclui referência à Issue #85.
- [x] Inclui @SC-001 no corpo.
- [x] Alterações mínimas, sem afetar outros jobs.

## Contexto / Referências
- Issue: #85
- Evidências da validação prática em `temp_issue/issue-85-resumo.md`.
- Runs de validação anteriores confirmaram publicação de artifacts em falha e sucesso.

@SC-001
