### PR TITLE
chore(gitignore): ignorar artifacts_download/ (artifacts locais do CI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test-results/
 .vite/
 scripts/dist/
 artifacts/
+artifacts_download/
 .idea/
 .vscode/
 .DS_Store


### PR DESCRIPTION
Ignora a pasta local de download de artifacts do CI (artifacts_download/) para não poluir o git status com evidências baixadas (ex.: zap-*).