### PR TITLE
docs(ci): alinhar docs com artefatos ZAP e summary (#85)

### DIFF
--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -88,6 +88,13 @@ Notas de governança relacionadas:
 - O script `scripts/security/run_dast.sh` aplica migrações e inicia o `runserver` antes do scan; aguarda o endpoint responder.
 - Política (atualizada em 2025‑11‑08): em PRs, `main`, `release/*` e tags é fail‑closed (sem `fail‑open`). Em `workflow_dispatch`, segue política de sanidade do workflow.
   - Tratamento de severidade: WARN não quebra pipeline (exit 2 do ZAP é normalizado para sucesso); FAIL quebra (exit 1/3) — reduz ruído mantendo fail‑closed para vulnerabilidades reais.
+ - Artefatos publicados (artifact `zap-reports`):
+   - `zap-baseline.json` (JSON do baseline)
+   - `zap-report.html` (relatório navegável)
+   - `zap-report.xml` (máquina/CI)
+   - `zap-warnings.md` (resumo textual de avisos)
+   - `django-zap.log` (log do backend durante o scan)
+ - Resumo no Job Summary: o workflow grava no `$GITHUB_STEP_SUMMARY` a linha com o outcome do DAST e o caminho dos artefatos ("Artifacts: artifacts/zap").
 
 ## Notas SCA (Python)
 - Ferramentas: `pip-audit` e `Safety` executam no job “Security Checks”.


### PR DESCRIPTION
## Descrição

Atualiza a documentação de checks obrigatórios do CI para refletir o estado atual do DAST (ZAP):
- Lista explícita dos artefatos publicados (`zap-reports`): `zap-baseline.json`, `zap-report.html`, `zap-report.xml`, `zap-warnings.md`, `django-zap.log`.
- Menciona que o workflow escreve o outcome e o caminho dos artefatos no Job Summary (`$GITHUB_STEP_SUMMARY`).

## Checklist
- [x] Título segue Conventional Commits.
- [x] Inclui referência à Issue #85.
- [x] Inclui @SC-001 no corpo.

## Contexto / Referências
- Issue: #85
- Implementação: PR #124 (artefatos e logs do ZAP no CI)

@SC-001
