### PR TITLE
ci: Etapa 1 canário (#86) - Renovate ^39 e Poetry --sync

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -281,7 +281,7 @@ jobs:
         run: poetry --version | grep '1.8.3'
 
       - name: Install Python dependencies
-        run: poetry install --with dev --no-ansi --no-interaction
+        run: poetry install --no-interaction --no-ansi --sync --with dev
 
       - name: Garantir que poetry.lock não foi alterado
         run: git diff --exit-code poetry.lock
@@ -626,7 +626,7 @@ jobs:
 
       - name: Install Python dependencies
         if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
-        run: poetry install --with dev --no-ansi --no-interaction
+        run: poetry install --no-interaction --no-ansi --sync --with dev
 
       - name: Garantir que poetry.lock não foi alterado
         if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Validate Renovate schema (renovate-config-validator)
         run: |
           set -euo pipefail
-          npx --yes -p renovate@latest renovate-config-validator --strict renovate.json
+          npx --yes -p renovate@^39 renovate-config-validator --strict renovate.json
 
       - name: Ensure assignees configurados
         run: |


### PR DESCRIPTION
Etapa 1 do canário (#86)

- Pin Renovate validator em ^39 compatível com Node 22.13.x.
- Poetry install com --sync mantendo --with dev nos jobs de teste/segurança.

Validações locais:
- Não há mais uso de renovate@latest.
- poetry install atualizado em todos os steps do workflow alvo.
- Sem alterações em cache pnpm, pre-commit ou DB.