### PR TITLE
docs(ci): alinhar documentação ao estado do CI pós-#86

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ A pipeline principal executa e/ou exige:
 - Segurança (SAST/DAST/SCA, pgcrypto, SBOM) com enforcement estrito em `main`/release.
 - Threat model lint.
 - CI Outage Guard: fail‑open em branches não release para ferramentas de QA; fail‑closed em `main`/`release/*`/`hotfix/*`.
+- Pre-commit (lint hooks): job leve que prepara Node/pnpm e Poetry e executa os hooks definidos em `.pre-commit-config.yaml` (ESLint/Ruff), com resumo no Job Summary.
 
 ### Onde consultar gates do CI (sem duplicar valores)
 - Workflow principal: `.github/workflows/frontend-foundation.yml:1`

--- a/docs/adr/008-ferramenta-de-automacao-de-dependencias.md
+++ b/docs/adr/008-ferramenta-de-automacao-de-dependencias.md
@@ -13,6 +13,6 @@
 
 **Operacionalização no CI:**
 - A configuração é validada pelo workflow `.github/workflows/renovate-validation.yml` usando `renovate-config-validator` com `--strict`.
-- O job fixa Node `22.13.0` por compatibilidade com `renovate@latest`.
+- O job fixa Node `22.13.0` por compatibilidade com `renovate@^39`.
 - Migrações comuns que podem causar falha no validador: `matchPaths → matchFileNames`, `stabilityDays → minimumReleaseAge`, e schedules compostos devem ser divididos em entradas separadas.
 - Runbook: `docs/runbooks/renovate-validation.md`.

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -62,6 +62,7 @@ Estes são os contextos atualmente exigidos na proteção da branch `main` (Bran
 - Threat Model Lint
 - CI Outage Guard
 - CI Diagnostics
+- Validate Renovate configuration
 
 Nota — CI Outage Guard (permissões para anotar PR)
 - Para que o Outage Guard possa rotular/comentar PRs quando houver outage, o workflow principal precisa do bloco `permissions` com:

--- a/docs/runbooks/renovate-validation.md
+++ b/docs/runbooks/renovate-validation.md
@@ -4,13 +4,13 @@ Objetivo: validar a configuração do Renovate (`renovate.json`) no CI usando o 
 
 ## Workflow
 - Arquivo: `.github/workflows/renovate-validation.yml`.
-- Disparo: `workflow_dispatch`, `push` (branch `main`) e `pull_request` quando `renovate.json` muda.
-- Ambiente: Node `22.13.0` (necessário porque `renovate@latest` requer Node ≥ 22.13).
+- Disparo: `workflow_dispatch`, `push` (branch `main`) e `pull_request` (todos os PRs).
+- Ambiente: Node `22.13.0` (necessário porque `renovate@^39` requer Node ≥ 22.13).
 
 ## Passos principais
 1. Checkout do repositório.
 2. Setup Node 22.13.0 (`actions/setup-node@v4`).
-3. Validação: `npx --yes -p renovate@latest renovate-config-validator --strict renovate.json`.
+3. Validação: `npx --yes -p renovate@^39 renovate-config-validator --strict renovate.json`.
 4. Verificação adicional: garante que `assignees` estejam configurados e válidos.
 
 ## Sintomas comuns e correções


### PR DESCRIPTION
Atualiza runbook e ADR do Renovate para @^39, inclui 'Validate Renovate configuration' nos Required Checks e documenta o job leve de Pre-commit no CI.