### PR TITLE
ci: validar #139 #135 #140 — pnpm exec; cache pnpm-lock; Playwright chromium + cache por versão

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -33,8 +33,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies (pnpm)
         if: ${{ hashFiles('package.json') != '' }}
@@ -45,7 +43,7 @@ jobs:
         run: |
           if command -v pnpm >/dev/null 2>&1; then
             if [ -n "$(ls contracts 2>/dev/null)" ]; then
-              pnpm dlx @stoplight/spectral@6 lint contracts/**/*.yaml || exit 1
+              pnpm exec spectral lint contracts/**/*.yaml || exit 1
             else
               echo "::warning::No contracts directory to lint"
             fi
@@ -58,7 +56,7 @@ jobs:
         run: |
           if command -v pnpm >/dev/null 2>&1; then
             if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-              pnpm dlx openapi-diff contracts/api.previous.yaml contracts/api.yaml
+              pnpm exec openapi-diff contracts/api.previous.yaml contracts/api.yaml
             else
               echo "::warning::OpenAPI baseline missing; skipping diff"
             fi

--- a/.github/workflows/ci-outage-selftest.yml
+++ b/.github/workflows/ci-outage-selftest.yml
@@ -27,8 +27,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -91,8 +89,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -175,8 +175,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -205,8 +203,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -289,8 +285,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -407,8 +401,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         if: ${{ needs.changes.outputs.contracts == 'true' }}
@@ -453,8 +445,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         if: ${{ needs.changes.outputs.ui == 'true' }}
@@ -469,9 +459,23 @@ jobs:
         timeout-minutes: 15
         run: pnpm --filter @iabank/frontend-foundation storybook:build
 
+      - name: Detectar versão do Playwright (UI)
+        if: ${{ needs.changes.outputs.ui == 'true' }}
+        id: pwver_ui
+        run: |
+          echo "version=$(pnpm --filter @iabank/frontend-foundation exec playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright (UI)
+        if: ${{ needs.changes.outputs.ui == 'true' }}
+        id: pwcache_ui
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ steps.pwver_ui.outputs.version }}
+
       - name: Instalar navegadores Playwright (apenas Chromium)
         if: ${{ needs.changes.outputs.ui == 'true' }}
-        run: pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps chromium
+        run: pnpm --filter @iabank/frontend-foundation exec playwright install chromium
 
       - name: Executar Chromatic
         if: ${{ needs.changes.outputs.ui == 'true' && github.event_name == 'pull_request' && env.CHROMATIC_PROJECT_TOKEN != '' }}
@@ -540,8 +544,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Setup k6
         if: ${{ needs.changes.outputs.ui == 'true' }}
@@ -555,9 +557,23 @@ jobs:
         run: |
           echo "UI changed? -> ${{ needs.changes.outputs.ui }}"
 
+      - name: Detectar versão do Playwright (Perf)
+        if: ${{ needs.changes.outputs.ui == 'true' }}
+        id: pwver_perf
+        run: |
+          echo "version=$(pnpm --filter @iabank/frontend-foundation exec playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright (Perf)
+        if: ${{ needs.changes.outputs.ui == 'true' }}
+        id: pwcache_perf
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ steps.pwver_perf.outputs.version }}
+
       - name: Instalar navegadores Playwright (apenas Chromium)
         if: ${{ needs.changes.outputs.ui == 'true' }}
-        run: pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps chromium
+        run: pnpm --filter @iabank/frontend-foundation exec playwright install chromium
 
       - name: Preparar artefatos de performance
         if: ${{ needs.changes.outputs.ui == 'true' }}
@@ -669,8 +685,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Setup Python
         id: setup_py_sec
@@ -886,8 +900,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: |
             pnpm-lock.yaml
-            scripts/**
-            frontend/scripts/**
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Guia rápido para executar a suíte completa de validações localmente (fronten
 - Node.js 20 e pnpm 9 (ver `package.json` → `packageManager`)
 - Python 3.11 + Poetry 1.8.3 (alinhado a CI/Docker)
 - k6 CLI (para testes de performance)
-- Playwright (navegadores): `pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps`
+ - Playwright (navegadores): `pnpm --filter @iabank/frontend-foundation exec playwright install`
 
 ## Serviços (Postgres/Redis)
 Você pode usar serviços locais ou subir via Docker Compose (porta alta para evitar conflitos):
@@ -51,7 +51,7 @@ python -m pip install -U pip && pip install "poetry==1.8.3"
 poetry install --with dev --sync --no-interaction --no-ansi
 
 # Playwright browsers
-pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps
+pnpm --filter @iabank/frontend-foundation exec playwright install
 ```
 
 ## Suíte completa (1 comando)
@@ -188,7 +188,7 @@ docker rm -f infra-prometheus infra-grafana
 ```
 
 ## Troubleshooting rápido
-- Playwright: rode `pnpm --filter @iabank/frontend-foundation exec playwright install --with-deps` se faltar navegador.
+- Playwright: rode `pnpm --filter @iabank/frontend-foundation exec playwright install` se faltar navegador.
 - Postgres/Redis: ajuste portas em `infra/docker-compose.foundation.yml` via `FOUNDATION_STACK_POSTGRES_PORT` e `FOUNDATION_STACK_REDIS_PORT`.
 - OTEL (k6): para publicar métricas, defina `OTEL_EXPORTER_OTLP_ENDPOINT` (ex.: `http://localhost:4318`).
 - Grafana: se o painel não aparecer, reinicie o container para reprocessar o provisioning (`docker restart infra-grafana`) e valide os volumes montados em `infra/grafana/provisioning`.

--- a/frontend/.ci-validate
+++ b/frontend/.ci-validate
@@ -1,0 +1,1 @@
+gatilho de validação de UI via paths-filter

--- a/frontend/.ci-validate
+++ b/frontend/.ci-validate
@@ -1,1 +1,0 @@
-gatilho de validação de UI via paths-filter


### PR DESCRIPTION
Este PR valida na prática as issues #139, #135 e #140:\n\n- #139: troca pnpm dlx→exec e cache Node para apenas pnpm-lock.yaml\n- #135: Playwright install sem --with-deps, apenas chromium\n- #140: Cache de browsers do Playwright por versão (path ~/.cache/ms-playwright)\n\nForça paths-filter de UI via frontend/.ci-validate.\n