### PR TITLE
ci: gates por path + pre-commit incremental (#136, #138)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -270,7 +270,7 @@ jobs:
           echo -e "pre-commit outcome: ${{ steps.precommit.outcome }}" >> "$GITHUB_STEP_SUMMARY"
 
   test:
-    name: Tests (FE/BE gates)
+    name: Vitest
     runs-on: ubuntu-latest
     needs: [lint, changes]
     services:

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -190,6 +190,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -242,9 +244,25 @@ jobs:
       - name: Install Python dependencies
         run: poetry install --no-interaction --no-ansi --sync --with dev
 
-      - name: Run pre-commit
+      - name: Run pre-commit (incremental em PR; full em main/tags)
         id: precommit
-        run: poetry run pre-commit run --all-files --show-diff-on-failure
+        run: |
+          set -euo pipefail
+          echo "event_name=${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.sha }}"
+            if [ -n "$BASE" ]; then
+              echo "Executando pre-commit por diff: $BASE..$HEAD"
+              poetry run pre-commit run --from-ref "$BASE" --to-ref "$HEAD" --show-diff-on-failure
+            else
+              echo "::warning::BASE SHA ausente; executando full scan (--all-files)."
+              poetry run pre-commit run --all-files --show-diff-on-failure
+            fi
+          else
+            echo "Evento não é PR (main/releases/tags) — executando full scan."
+            poetry run pre-commit run --all-files --show-diff-on-failure
+          fi
 
       - name: Resumo (pre-commit)
         if: always()
@@ -254,7 +272,7 @@ jobs:
   test:
     name: Vitest
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, changes]
     services:
       postgres:
         image: postgres:15
@@ -274,11 +292,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        if: ${{ needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: pnpm/action-setup@v2
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
+        if: ${{ needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -287,10 +307,11 @@ jobs:
             pnpm-lock.yaml
 
       - name: Install dependencies
+        if: ${{ needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: pnpm install --frozen-lockfile
 
       - name: Run Vitest (coverage gate) — PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.frontend == 'true' }}
         env:
           FOUNDATION_COVERAGE_BRANCHES: '85'
         run: pnpm test:coverage
@@ -302,7 +323,7 @@ jobs:
         run: pnpm test:coverage
 
       - name: Run Vitest (coverage gate) — dev branches
-        if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/tags/') && needs.changes.outputs.frontend == 'true' }}
         env:
           FOUNDATION_COVERAGE_BRANCHES: '85'
         run: pnpm test:coverage
@@ -318,12 +339,14 @@ jobs:
           fi
 
       - name: Setup Python
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         id: setup_py_test
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Cache Poetry
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
@@ -333,6 +356,7 @@ jobs:
             ${{ runner.os }}-pypoetry-
 
       - name: Cache pip
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -342,6 +366,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry==1.8.3
@@ -349,15 +374,19 @@ jobs:
       # e versões recentes (>=1.9) exigem Poetry 2.x, conflitando com 1.8.x.
 
       - name: Verificar versão do Poetry (1.8.3)
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry --version | grep '1.8.3'
 
       - name: Install Python dependencies
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry install --no-interaction --no-ansi --sync --with dev
 
       - name: Garantir que poetry.lock não foi alterado
+        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: git diff --exit-code poetry.lock
 
       - name: Pytest (coverage gate)
+        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
         env:
           FOUNDATION_DB_VENDOR: postgresql
           FOUNDATION_DB_NAME: foundation
@@ -370,6 +399,7 @@ jobs:
           poetry run pytest || (echo 'Pytest falhou; reexecutando uma vez...' && sleep 3 && poetry run pytest)
 
       - name: Radon complexity gate
+        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
         run: poetry run python scripts/ci/check_python_complexity.py
 
   contracts:

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -270,7 +270,7 @@ jobs:
           echo -e "pre-commit outcome: ${{ steps.precommit.outcome }}" >> "$GITHUB_STEP_SUMMARY"
 
   test:
-    name: Vitest
+    name: Tests (FE/BE gates)
     runs-on: ubuntu-latest
     needs: [lint, changes]
     services:
@@ -290,6 +290,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resumo de mudanças (tests)
+        run: |
+          echo "frontend changed? -> ${{ needs.changes.outputs.frontend }}"
+          echo "backend changed? -> ${{ needs.changes.outputs.backend }}"
 
       - name: Setup pnpm
         if: ${{ needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}


### PR DESCRIPTION

ci: gates por path + pre-commit incremental (#136, #138)

## Contexto
- Implementa pre-commit incremental por diff em PRs; full scan em main/releases/tags.
- Implementa gates por paths no job de testes: FE (Vitest) roda só quando frontend muda; BE (Pytest/Radon) roda só quando backend muda; sempre roda em main/releases/tags.

## Checklist
- [x] Inclui pelo menos uma tag @SC-00x no PR (ex.: @SC-001)
- [x] Pre-commit incremental validado em PR FE/BE
- [x] Gates FE/BE validados em PR FE/BE e branch release

## Evidências
- PR FE: apenas frontend alterado — Vitest executou; Pytest/Radon não executaram; pre-commit por diff.
- PR BE: apenas backend alterado — Pytest/Radon executaram; Vitest não; pre-commit por diff.
- release/*: executaram Vitest strict e Pytest/Radon.
