### PR TITLE
docs(ci): documenta pre-commit incremental e gates por paths (Lote 2)

### DIFF
--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -37,6 +37,17 @@ Reflete os gates constitucionais (v5.2.0) e ADRs 008–012.
 
 Nota operacional: esta seção foi ajustada apenas para validar o comportamento de gating em um PR "docs-only".
 
+## Atualizações (2025-11-11) — Lote 2
+- Pre-commit incremental por diff (PR):
+  - `actions/checkout@v4` com `fetch-depth: 0` para garantir histórico e permitir `--from-ref/--to-ref`.
+  - PRs executam `pre-commit run --from-ref $BASE --to-ref $HEAD --show-diff-on-failure`.
+  - Em `main`/`release/*`/tags, executa `--all-files`.
+- Gates por paths no job “Vitest” (tests):
+  - Node/pnpm + “Run Vitest (coverage gate)” executam quando `needs.changes.outputs.frontend == 'true'` ou sempre em `main`/`release/*`/tags.
+  - Python/Poetry + “Pytest (coverage gate)” e “Radon complexity gate” executam quando `needs.changes.outputs.backend == 'true'` ou sempre em `main`/`release/*`/tags.
+  - O job depende de `changes` (`needs: [lint, changes]`) e consome os outputs `frontend`/`backend` do filtro.
+  - Observação: o nome do job permanece “Vitest” por requisito de Branch Protection; não renomear sem atualizar a regra.
+
 ## Prova de TDD (Art. III)
 - PRs DEVEM evidenciar “vermelho → verde” para mudanças de código:
   - Inclua no corpo do PR os commits/links para: (1) estado vermelho (testes falhando) e (2) estado verde (após implementação).

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -35,6 +35,15 @@ Evidências de Rollout & Gates
 - `SC-005`: arquive o resultado do comando `python scripts/observability/check_structlog.py <log>` (aplicado nos logs do deploy) e registre captura do painel “SC-005 — Incidentes PII (30d)”. Confirme também a ausência de sinais no painel “Error Budget Consumido (%)”.
 - Error budget: se o painel atingir ≥ 80%, abra incidente no template `docs/runbooks/incident-response.md`, pause deploys e anexe no README as ações de mitigação planejadas.
 
+Notas CI — Lote 2 (2025‑11‑11)
+- Pre-commit incremental (PR): o log do job “Pre-commit (lint hooks)” deve conter a linha
+  "Executando pre-commit por diff: $BASE..$HEAD". Em `main`/`release/*`/tags o job executa full scan.
+- Gates por paths no job “Vitest”:
+  - O passo “Resumo de mudanças (tests)” imprime `frontend changed?` e `backend changed?` com base nos outputs do job `changes`.
+  - PR frontend-only: espera “Vitest sim” e “Pytest/Radon não”. PR backend-only: espera “Pytest/Radon sim” e “Vitest não”.
+  - Em `main`/`release/*`/tags: ambos executam.
+  - Dica com gh: `gh run view <RUN_ID> --log | rg -n "Run Vitest|Pytest (coverage gate)|Radon complexity gate"`.
+
 Ativação de Flags por Tenant
 1) Validar pipelines verdes para a PR (lint, test, contracts, visual-accessibility, performance, security, SBOM).
 2) Habilitar `foundation.fsd` para um tenant piloto (canary) em 5–10% dos usuários.


### PR DESCRIPTION
Atualiza a documentação do CI após o Lote 2:
- Pre-commit incremental em PRs (diff base/head) e full em main/releases/tags.
- Gates por paths no job de testes (Vitest/Node vs Pytest/Radon), com exemplos de diagnóstico.
- Observação: manter o nome do job “Vitest” por ser Required Check.
Arquivos: CONTRIBUTING.md; docs/pipelines/ci-required-checks.md; docs/runbooks/frontend-foundation.md.