### PR TITLE
ci(workflow): suportar testes Python com TS e exportar logs do Pytest @SC-001

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -351,6 +351,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup pnpm (deps para testes Python)
+        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js (deps para testes Python)
+        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+
+      - name: Install Node dependencies (para scripts TS usados pelos testes)
+        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        run: pnpm install --frozen-lockfile
+
       - name: Resumo de mudanças (tests - backend)
         run: |
           echo "frontend changed? -> ${{ needs.changes.outputs.frontend }}"

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -414,11 +414,23 @@ jobs:
           FOUNDATION_DB_PORT: 5432
           FOUNDATION_DB_TEST_NAME: foundation_test
         run: |
-          poetry run pytest || (echo 'Pytest falhou; reexecutando uma vez...' && sleep 3 && poetry run pytest)
+          set -o pipefail
+          mkdir -p artifacts/pytest
+          poetry run pytest | tee artifacts/pytest/pytest.log || (
+            echo 'Pytest falhou; reexecutando uma vez...' | tee -a artifacts/pytest/pytest.log;
+            sleep 3;
+            poetry run pytest | tee -a artifacts/pytest/pytest.log
+          )
 
       - name: Radon complexity gate
         if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
         run: poetry run python scripts/ci/check_python_complexity.py
+      - name: Upload pytest logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-logs
+          path: artifacts/pytest
 
   contracts:
     name: Contracts (Spectral, OpenAPI Diff, Pact)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,11 @@ A pipeline principal executa e/ou exige:
   - O checkout do job usa `fetch-depth: 0` para garantir diffs confiáveis.
   - Hooks definidos em `.pre-commit-config.yaml` (ESLint/Ruff); o job grava um resumo no Job Summary.
 
-- Testes (gates por paths):
-  - O job “Vitest” prepara Node e executa Vitest somente quando há mudanças no frontend (outputs de `changes`), e SEMPRE em `main`/`release/*`/tags.
-  - No mesmo job, a preparação de Python e os passos Pytest/Radon executam somente quando há mudanças no backend (outputs de `changes`), e SEMPRE em `main`/`release/*`/tags.
-  - Dica: o passo “Resumo de mudanças (tests)” imprime `needs.changes.outputs.frontend/backend` para diagnóstico rápido.
-  - Importante: “Vitest” é um Required Check. Não renomeie o job sem atualizar as Branch Protection Rules.
+- Testes (gates por paths) — Lote 3:
+  - “Vitest” (job `test-frontend`): prepara Node e executa Vitest quando `needs.changes.outputs.frontend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
+  - “Pytest + Radon” (job `test-backend`): prepara Python/Poetry e executa Pytest/Radon quando `needs.changes.outputs.backend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
+  - Dica: os passos “Resumo de mudanças (tests - frontend/backend)” imprimem `needs.changes.outputs.frontend/backend` para diagnóstico rápido.
+  - Required checks: se “Vitest” já for required, avalie adicionar “Pytest + Radon” às Branch Protection Rules (nome exato do job).
 
 ### Onde consultar gates do CI (sem duplicar valores)
 - Workflow principal: `.github/workflows/frontend-foundation.yml:1`

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -42,11 +42,15 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
   - `actions/checkout@v4` com `fetch-depth: 0` para garantir histórico e permitir `--from-ref/--to-ref`.
   - PRs executam `pre-commit run --from-ref $BASE --to-ref $HEAD --show-diff-on-failure`.
   - Em `main`/`release/*`/tags, executa `--all-files`.
-- Gates por paths no job “Vitest” (tests):
-  - Node/pnpm + “Run Vitest (coverage gate)” executam quando `needs.changes.outputs.frontend == 'true'` ou sempre em `main`/`release/*`/tags.
-  - Python/Poetry + “Pytest (coverage gate)” e “Radon complexity gate” executam quando `needs.changes.outputs.backend == 'true'` ou sempre em `main`/`release/*`/tags.
-  - O job depende de `changes` (`needs: [lint, changes]`) e consome os outputs `frontend`/`backend` do filtro.
-  - Observação: o nome do job permanece “Vitest” por requisito de Branch Protection; não renomear sem atualizar a regra.
+## Atualizações (2025-11-11) — Lote 3
+- Testes paralelos: dividido em dois jobs — `test-frontend` (Vitest) e `test-backend` (Pytest + Radon), ambos com `needs: [lint, changes]` e execução paralela.
+- Gates por paths nos testes:
+  - Vitest: executa quando `needs.changes.outputs.frontend == 'true'` (PR/dev) e SEMPRE em `main`/`release/*`/tags.
+  - Pytest + Radon: executa quando `needs.changes.outputs.backend == 'true'` (PR/dev) e SEMPRE em `main`/`release/*`/tags.
+- Contracts:
+  - `contracts` não depende mais de `test`.
+  - Pact consumer verification roda quando `contracts == 'true'` OU `frontend == 'true'`.
+  - Spectral/OpenAPI diff roda apenas quando `contracts == 'true'`.
 
 ## Prova de TDD (Art. III)
 - PRs DEVEM evidenciar “vermelho → verde” para mudanças de código:
@@ -66,6 +70,7 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
 Estes são os contextos atualmente exigidos na proteção da branch `main` (Branch protection rules). Mantemos a lista aqui para referência rápida e auditoria:
 - Lint
 - Vitest
+- Pytest + Radon
 - Contracts (Spectral, OpenAPI Diff, Pact)
 - Visual & Accessibility Gates
 - Performance Budgets

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -35,13 +35,12 @@ Evidências de Rollout & Gates
 - `SC-005`: arquive o resultado do comando `python scripts/observability/check_structlog.py <log>` (aplicado nos logs do deploy) e registre captura do painel “SC-005 — Incidentes PII (30d)”. Confirme também a ausência de sinais no painel “Error Budget Consumido (%)”.
 - Error budget: se o painel atingir ≥ 80%, abra incidente no template `docs/runbooks/incident-response.md`, pause deploys e anexe no README as ações de mitigação planejadas.
 
-Notas CI — Lote 2 (2025‑11‑11)
+Notas CI — Lote 3 (2025‑11‑11)
 - Pre-commit incremental (PR): o log do job “Pre-commit (lint hooks)” deve conter a linha
   "Executando pre-commit por diff: $BASE..$HEAD". Em `main`/`release/*`/tags o job executa full scan.
-- Gates por paths no job “Vitest”:
-  - O passo “Resumo de mudanças (tests)” imprime `frontend changed?` e `backend changed?` com base nos outputs do job `changes`.
-  - PR frontend-only: espera “Vitest sim” e “Pytest/Radon não”. PR backend-only: espera “Pytest/Radon sim” e “Vitest não”.
-  - Em `main`/`release/*`/tags: ambos executam.
+- Gates por paths nos testes:
+  - “Vitest” (job `test-frontend`) roda quando `frontend == 'true'` (PR/dev) e sempre em `main`/`release/*`/tags.
+  - “Pytest + Radon” (job `test-backend`) roda quando `backend == 'true'` (PR/dev) e sempre em `main`/`release/*`/tags.
   - Dica com gh: `gh run view <RUN_ID> --log | rg -n "Run Vitest|Pytest (coverage gate)|Radon complexity gate"`.
 
 Ativação de Flags por Tenant
@@ -119,7 +118,7 @@ Pontos de Contato
 - Jobs:
   - CI Diagnostics: https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406825564 (success)
   - Lint: https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406825581 (success)
-  - Vitest (inclui Pytest): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406870319 (success)
+  - Vitest (na época incluía Pytest; hoje separado em “Vitest” e “Pytest + Radon”): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406870319 (success)
     - Coverage Vitest: All files — Statements 95.17%, Lines 95.17%, Functions 88.88%, Branches 84.75.
     - Coverage Pytest: TOTAL 87%.
   - Contracts (Spectral, OpenAPI Diff, Pact): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406986661 (success)
@@ -139,7 +138,7 @@ Pontos de Contato
 
 ### Evidências PR #12 — run verde
 - Workflow (pull_request): https://github.com/Tomvaz11/iabank/actions/runs/19050934281
-- Jobs (principais): Lint (success); Vitest/Pytest (success); Contracts (success); Visual & A11y (success — Chromatic executado; test‑runner sem violações); Performance (success — k6 e Lighthouse tolerantes); Security Checks (success — PR fail‑open).
+- Jobs (principais): Lint (success); Vitest e Pytest + Radon (success); Contracts (success); Visual & A11y (success — Chromatic executado; test‑runner sem violações); Performance (success — k6 e Lighthouse tolerantes); Security Checks (success — PR fail‑open).
   - ATUALIZAÇÃO 2025‑11‑08: gates de Performance e Segurança agora são estritos também nos PRs (fail‑closed). O workflow temporário “Quick Perf+Security Check” foi removido.
 
 Resumo consolidado
@@ -157,7 +156,7 @@ Pipelines em `main`
 - Conferir últimos runs do workflow `frontend-foundation.yml` na `main`:
   - `gh run list --workflow=frontend-foundation.yml --branch main --limit 3`
   - `gh run view <RUN_ID> --log`
-- Esperado: Lint, Testes (Vitest/Pytest), Contracts, Security, Threat Model, CI Outage Guard em sucesso; Visual/Performance conforme políticas do PR/base.
+- Esperado: Lint, Testes (Vitest e Pytest + Radon), Contracts, Security, Threat Model, CI Outage Guard em sucesso; Visual/Performance conforme políticas do PR/base.
 
 Sincronização GitOps (Argo CD)
 - Aplicação: `frontend-foundation`
@@ -196,7 +195,7 @@ Observabilidade (24–48h)
 
 - Pipelines em `main`
   - Último run (manual, workflow_dispatch) em `main`: https://github.com/Tomvaz11/iabank/actions/runs/19048561651 — Status: SUCESSO.
-  - Jobs esperados: Lint, Vitest/Pytest, Contracts, Security, Threat Model, CI Outage Guard. Visual/Performance são pulados em `workflow_dispatch` por política.
+  - Jobs esperados: Lint, Vitest, Pytest + Radon, Contracts, Security, Threat Model, CI Outage Guard. Visual/Performance podem ser pulados em `workflow_dispatch` por política.
 
 - Artefatos de referência
   - Lighthouse (mais recente): `observabilidade/data/lighthouse-latest.json`.


### PR DESCRIPTION
## Checklist

- [x] inclui pelo menos uma tag @SC-00x
- [x] validação prática (PR: feature/lote-3-ci) para fixes de backend

### Contexto
- Corrige falhas do Pytest por ausência do TypeScript (tsc) no job test-backend.

### Mudanças
- test-backend: adiciona setup de Node/pnpm e pnpm install antes do Pytest.
- test-backend: exporta logs do Pytest como artifact (pytest-logs).
- Docs atualizadas para Lote 3.
