### PR TITLE
ci(frontend): timeouts de jobs Performance (30m) e Security (25m) (#134)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -606,6 +606,7 @@ jobs:
       VITE_FOUNDATION_TRUSTED_TYPES_POLICY: foundation-ui
       VITE_FOUNDATION_PGCRYPTO_KEY: ci-only-pgcrypto-key
       LIGHTHOUSE_ARTIFACT_DIR: ${{ github.workspace }}/artifacts/lighthouse
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -738,6 +739,7 @@ jobs:
       FOUNDATION_DB_NAME: foundation
       FOUNDATION_DB_USER: foundation
       FOUNDATION_DB_PASSWORD: foundation
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Implementa issue #134 adicionando timeouts em nível de job no workflow Frontend Foundation CI.\n\n- Job Performance Budgets: timeout-minutes: 30\n- Job Security Checks: timeout-minutes: 25\n- Timeouts de steps preservados (Chromatic, Lighthouse etc.)\n\nValidações locais: buscas com rg confirmam inserções e preservação de timeouts existentes.\n\nApós abrir o PR, vou disparar o workflow via workflow_dispatch na branch para validação real.