### PR TITLE
ci(workflows): garantir execução do Pytest quando mudar apenas tests/backend/**

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -39,6 +39,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       security: ${{ steps.filter.outputs.security }}
+      tests: ${{ steps.filter.outputs.tests }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +74,8 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+            tests:
+              - 'tests/backend/**'
             security:
               - 'scripts/security/**'
               - 'scripts/ci/**'
@@ -352,13 +355,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm (deps para testes Python)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         uses: pnpm/action-setup@v2
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js (deps para testes Python)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -367,23 +370,24 @@ jobs:
             pnpm-lock.yaml
 
       - name: Install Node dependencies (para scripts TS usados pelos testes)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         run: pnpm install --frozen-lockfile
 
       - name: Resumo de mudanças (tests - backend)
         run: |
           echo "frontend changed? -> ${{ needs.changes.outputs.frontend }}"
           echo "backend changed? -> ${{ needs.changes.outputs.backend }}"
+          echo "tests (backend) changed? -> ${{ needs.changes.outputs.tests }}"
 
       - name: Setup Python
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         id: setup_py_test
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Cache Poetry
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
@@ -393,7 +397,7 @@ jobs:
             ${{ runner.os }}-pypoetry-
 
       - name: Cache pip
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -403,7 +407,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry==1.8.3
@@ -411,19 +415,19 @@ jobs:
       # e versões recentes (>=1.9) exigem Poetry 2.x, conflitando com 1.8.x.
 
       - name: Verificar versão do Poetry (1.8.3)
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry --version | grep '1.8.3'
 
       - name: Install Python dependencies
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry install --no-interaction --no-ansi --sync --with dev
 
       - name: Garantir que poetry.lock não foi alterado
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: git diff --exit-code poetry.lock
 
       - name: Pytest (coverage gate)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         env:
           FOUNDATION_DB_VENDOR: postgresql
           FOUNDATION_DB_NAME: foundation
@@ -442,7 +446,7 @@ jobs:
           )
 
       - name: Radon complexity gate
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         run: poetry run python scripts/ci/check_python_complexity.py
       - name: Upload pytest logs
         if: always()


### PR DESCRIPTION
## Descrição

Corrige o gating do job “Pytest + Radon” para que PRs que alterem apenas `tests/backend/**` também executem pytest (com cobertura) e o gate de complexidade (Radon).

## Checklist

- [x] Título segue Conventional Commits (ex.: `feat(scope): descrição`).
- [x] Inclui pelo menos uma tag `@SC-00x` (SC-001..SC-005) no título ou corpo, quando aplicável.
- [x] Não é PR isento de tag (@SC-00x) por prefixo (`chore/`, `ci/`, `docs/`, `tests/`) — N/A (não isento).
- [x] Se impacta UI, está ciente de que gates Visuais/A11y e Performance irão rodar. (N/A)
- [x] Se é "docs-only", confirmado que não há mudanças fora de `docs/**` e metadados. (N/A)

## Contexto / Referências

- Relaciona @SC-001
- Issue: #154

Contexto
- O job “Pytest + Radon” roda no PR apenas quando há mudanças em `backend/**` (ou sempre em main/releases/tags).
- PRs com mudanças somente em `tests/backend/**` não disparam o job, permitindo aprovar PRs sem rodar pytest/coverage.

O que foi feito (Opção A — corrigir o gating)
- Adicionado filtro `tests:` no job `changes` (paths-filter) para `tests/backend/**` e exposta a saída `needs.changes.outputs.tests`.
- Atualizadas as condições do job “Pytest + Radon” para também rodar quando `tests == 'true'` em PRs.
- Mantidas as demais condições para `main/release/tags` e ambientes onde já executa sempre.
- Não alteramos outros gates (frontend, contracts, security, performance), evitando efeitos colaterais.

Arquivos tocados
- .github/workflows/frontend-foundation.yml

Critérios de aceitação
- [x] PR alterando apenas arquivos em `tests/backend/**` dispara “Pytest + Radon”.
- [x] Cobertura mínima (85%) permanece aplicada (via `pytest.ini`).
- [x] Nenhum impacto indesejado nos demais gates.

Evidência/Validação
- Criei um PR draft de validação com alteração apenas em `tests/backend/**`: ele dispara “Pytest + Radon” como esperado.
- Link: #160

Closes #154