### PR TITLE
tests: PR de validação do gating do Pytest (tests-only)

### DIFF
--- a/tests/backend/.gating-proof.md
+++ b/tests/backend/.gating-proof.md
@@ -1,0 +1,1 @@
+Prova de gating: alteração somente em tests/backend/** para disparar Pytest + Radon.


### PR DESCRIPTION
Este PR altera apenas arquivos em tests/backend/** para validar que o job 'Pytest + Radon' roda quando somente testes do backend mudam. Deve marcar 'tests == true' e 'backend == false' no job 'changes', e executar 'test-backend'.