### PR TITLE
ci(contracts): alinhar Spectral (rulesets e CI) + docs (#155)

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -39,11 +39,12 @@ jobs:
         run: pnpm install --frozen-lockfile
         shell: bash
 
-      - name: Spectral lint (skips if not installed)
+      - name: Spectral lint (via pnpm openapi:lint)
         run: |
           if command -v pnpm >/dev/null 2>&1; then
             if [ -n "$(ls contracts 2>/dev/null)" ]; then
-              pnpm exec spectral lint contracts/**/*.yaml || exit 1
+              # Fonte única de verdade: usa o ruleset de contratos explicitamente
+              pnpm openapi:lint || exit 1
             else
               echo "::warning::No contracts directory to lint"
             fi

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -39,6 +39,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       security: ${{ steps.filter.outputs.security }}
+      tests: ${{ steps.filter.outputs.tests }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +74,8 @@ jobs:
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+            tests:
+              - 'tests/backend/**'
             security:
               - 'scripts/security/**'
               - 'scripts/ci/**'
@@ -352,13 +355,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm (deps para testes Python)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         uses: pnpm/action-setup@v2
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js (deps para testes Python)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -367,23 +370,24 @@ jobs:
             pnpm-lock.yaml
 
       - name: Install Node dependencies (para scripts TS usados pelos testes)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         run: pnpm install --frozen-lockfile
 
       - name: Resumo de mudanças (tests - backend)
         run: |
           echo "frontend changed? -> ${{ needs.changes.outputs.frontend }}"
           echo "backend changed? -> ${{ needs.changes.outputs.backend }}"
+          echo "tests (backend) changed? -> ${{ needs.changes.outputs.tests }}"
 
       - name: Setup Python
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         id: setup_py_test
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Cache Poetry
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
@@ -393,7 +397,7 @@ jobs:
             ${{ runner.os }}-pypoetry-
 
       - name: Cache pip
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -403,7 +407,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry==1.8.3
@@ -411,19 +415,19 @@ jobs:
       # e versões recentes (>=1.9) exigem Poetry 2.x, conflitando com 1.8.x.
 
       - name: Verificar versão do Poetry (1.8.3)
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry --version | grep '1.8.3'
 
       - name: Install Python dependencies
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: poetry install --no-interaction --no-ansi --sync --with dev
 
       - name: Garantir que poetry.lock não foi alterado
-        if: ${{ needs.changes.outputs.backend == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/') }}
         run: git diff --exit-code poetry.lock
 
       - name: Pytest (coverage gate)
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         env:
           FOUNDATION_DB_VENDOR: postgresql
           FOUNDATION_DB_NAME: foundation
@@ -442,7 +446,7 @@ jobs:
           )
 
       - name: Radon complexity gate
-        if: ${{ (github.event_name == 'pull_request' && needs.changes.outputs.backend == 'true') || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && needs.changes.outputs.backend == 'true') }}
+        if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         run: poetry run python scripts/ci/check_python_complexity.py
       - name: Upload pytest logs
         if: always()

--- a/contracts/.spectral.yaml
+++ b/contracts/.spectral.yaml
@@ -1,5 +1,5 @@
 extends:
-  - spectral:oas
+  - ../.spectral.yaml
 
 rules:
   info-description:

--- a/docs/runbooks/governanca-api.md
+++ b/docs/runbooks/governanca-api.md
@@ -6,6 +6,7 @@ Aplicação operacional do **ADR-011** e do Artigo XI da Constituição.
 1. **Contratos OpenAPI**
    - Confirme que o arquivo em `/contracts/api.yaml` foi atualizado.
    - Execute `pnpm run openapi:lint` (Spectral) e `pnpm run openapi:diff` (openapi-diff). Ambos DEVEM falhar o pipeline se houver erro.
+   - Padrão suportado: utilize sempre `pnpm openapi:lint` (não use `spectral lint` direto sem `--ruleset=contracts/.spectral.yaml`).
 2. **Testes de contrato (Pact)**
    - Rode `pnpm run pact:verify` e verifique publicação do pacto no broker.
    - Garanta que consumidores atualizaram verificações (`pact-broker can-i-deploy`).

--- a/tests/backend/.gating-proof.md
+++ b/tests/backend/.gating-proof.md
@@ -1,0 +1,1 @@
+Prova de gating: alteração somente em tests/backend/** para disparar Pytest + Radon.


### PR DESCRIPTION
## Contexto
Alinha o uso do Spectral entre workflows e padroniza documentação, conforme a Issue #155.

- Fonte única de verdade para lint: `pnpm openapi:lint` (usa `--ruleset=contracts/.spectral.yaml`).
- Ruleset de contratos agora herda do baseline global (`../.spectral.yaml`).
- Runbook passa a recomendar explicitamente `pnpm openapi:lint` (evita `spectral lint` direto sem ruleset).

## Mudanças
- CI auxiliar:
  - .github/workflows/ci-contracts.yml → troca `pnpm exec spectral lint contracts/**/*.yaml` por `pnpm openapi:lint`.
- Rulesets:
  - contracts/.spectral.yaml → `extends: ["../.spectral.yaml"]` (mantendo regras estritas: `info-description`, `operation-success-response`).
- Docs:
  - docs/runbooks/governanca-api.md → nota destacando o comando suportado `pnpm openapi:lint`.

## Validação local
- Spectral lint: `pnpm openapi:lint` → "No results with a severity of 'error' found!".
- OpenAPI diff: `pnpm openapi:diff` → `breakingDifferencesFound: false` (previous → current).
- Pact: `pnpm pact:verify` → 3 testes passando (consumer verification).

## Critérios de Aceitação (Issue #155)
- [x] `ci-contracts.yml` usa `pnpm openapi:lint` (mesma severidade do workflow principal).
- [x] Ruleset de contratos pode herdar do baseline global sem alterar resultado efetivo.
- [x] Documentação orienta a usar `pnpm openapi:lint` (não `spectral lint` na raiz).
- [x] Required checks inalterados (apenas alinhamento de comportamento).

## Risco/Impacto
Baixo. Ajuste em workflow auxiliar e herança de ruleset; sem alteração de gates do workflow principal.

Closes #155

## Checklist

- [x] Título segue Conventional Commits (ex.: ci(contracts): ...).
- [x] Inclui pelo menos uma tag @SC-00x no título ou corpo, quando aplicável.
- [x] Documentação atualizada conforme necessário.


Relaciona @SC-001
