### PR TITLE
test(backend): PR de validação do gating do Pytest (tests-only)

### DIFF
--- a/tests/backend/.gating-proof.md
+++ b/tests/backend/.gating-proof.md
@@ -1,0 +1,1 @@
+Prova de gating (PR tests-only): alteração apenas em tests/backend/** para disparar job Pytest + Radon.


### PR DESCRIPTION
## Descrição

Este PR altera apenas arquivos em `tests/backend/**` para validar que o job "Pytest + Radon" roda quando somente testes do backend mudam (evento `pull_request` para `main`).

## Checklist
- [x] Inclui pelo menos uma tag @SC-00x

## Contexto / Referências
- Referências: @SC-001
- Issue relacionada: #154 (implementação já mergeada na main).
