### PR TITLE
docs(ci): refletir gating do Pytest + Radon para backend OU tests/backend/** (follow-up #154)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ A pipeline principal executa e/ou exige:
 
 - Testes (gates por paths) — Lote 3:
   - “Vitest” (job `test-frontend`): prepara Node e executa Vitest quando `needs.changes.outputs.frontend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
-  - “Pytest + Radon” (job `test-backend`): prepara Python/Poetry e executa Pytest/Radon quando `needs.changes.outputs.backend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
-  - Dica: os passos “Resumo de mudanças (tests - frontend/backend)” imprimem `needs.changes.outputs.frontend/backend` para diagnóstico rápido.
+  - “Pytest + Radon” (job `test-backend`): prepara Python/Poetry e executa Pytest/Radon quando `needs.changes.outputs.backend == 'true'` OU `needs.changes.outputs.tests == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
+  - Dica: os passos “Resumo de mudanças (tests - frontend/backend/tests)” imprimem `needs.changes.outputs.frontend/backend/tests` para diagnóstico rápido.
   - Required checks: se “Vitest” já for required, avalie adicionar “Pytest + Radon” às Branch Protection Rules (nome exato do job).
 
 ### Onde consultar gates do CI (sem duplicar valores)

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -46,7 +46,7 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
 - Testes paralelos: dividido em dois jobs — `test-frontend` (Vitest) e `test-backend` (Pytest + Radon), ambos com `needs: [lint, changes]` e execução paralela.
 - Gates por paths nos testes:
   - Vitest: executa quando `needs.changes.outputs.frontend == 'true'` (PR/dev) e SEMPRE em `main`/`release/*`/tags.
-  - Pytest + Radon: executa quando `needs.changes.outputs.backend == 'true'` (PR/dev) e SEMPRE em `main`/`release/*`/tags.
+  - Pytest + Radon: executa quando `needs.changes.outputs.backend == 'true'` OU `needs.changes.outputs.tests == 'true'` (PR/dev) e SEMPRE em `main`/`release/*`/tags.
 - Contracts:
   - `contracts` não depende mais de `test`.
   - Pact consumer verification roda quando `contracts == 'true'` OU `frontend == 'true'`.

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -40,7 +40,7 @@ Notas CI — Lote 3 (2025‑11‑11)
   "Executando pre-commit por diff: $BASE..$HEAD". Em `main`/`release/*`/tags o job executa full scan.
 - Gates por paths nos testes:
   - “Vitest” (job `test-frontend`) roda quando `frontend == 'true'` (PR/dev) e sempre em `main`/`release/*`/tags.
-  - “Pytest + Radon” (job `test-backend`) roda quando `backend == 'true'` (PR/dev) e sempre em `main`/`release/*`/tags.
+  - “Pytest + Radon” (job `test-backend`) roda quando `backend == 'true'` OU `tests == 'true'` (PR/dev) e sempre em `main`/`release/*`/tags.
   - Dica com gh: `gh run view <RUN_ID> --log | rg -n "Run Vitest|Pytest (coverage gate)|Radon complexity gate"`.
 
 Notas CI — Lote 4 (2025‑11‑11)


### PR DESCRIPTION
Atualiza a documentação para alinhar com o PR #159, que passou a disparar o job ‘Pytest + Radon’ quando há mudanças em backend OU em tests/backend/**.\n\nArquivos:\n- CONTRIBUTING.md: menciona needs.changes.outputs.tests e ajusta dica de diagnóstico.\n- docs/runbooks/frontend-foundation.md: atualiza regra de execução.\n- docs/pipelines/ci-required-checks.md: atualiza regra de execução.\n\nMotivação:\n- Issue: #154 (já fechada) — este PR é apenas um follow-up de docs.\n\nImpacto:\n- Somente documentação. Nenhuma mudança funcional.\n