### PR TITLE
docs(pipelines): corrigir referência ao workflow de contratos

### DIFF
--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -5,7 +5,7 @@ Reflete os gates constitucionais (v5.2.0) e ADRs 008–012.
 ## Jobs Obrigatórios
 1. **tests-unit**: `pytest` (preferencialmente sharded com `xdist`), cobertura ≥85%.
 2. **tests-integration**: inclui cenários de RLS (`CREATE POLICY` + enforcement) e `factory-boy`.
-3. **tests-contract**: Spectral, openapi-diff, Pact (`ci/contracts.yml`) com cenários de idempotência e concorrência.
+3. **tests-contract**: Spectral, openapi-diff, Pact (`.github/workflows/ci-contracts.yml`) com cenários de idempotência e concorrência.
 4. **tests-security**: SAST, DAST, SCA, verificação de pgcrypto/mascaramento (scripts do ADR-010).
 5. **tests-performance**: k6 com thresholds definidos nos SLOs aprovados (documentar no repositório de SLOs/SLA) e revisados semestralmente.
 6. **build-sbom**: Gera CycloneDX/SPDX.


### PR DESCRIPTION
Atualiza doc para apontar o workflow correto: `.github/workflows/ci-contracts.yml`.\n\n- Evita referência inexistente ().\n- Mantém consistência com a padronização feita na #155 (fonte única: `pnpm openapi:lint`).