### PR TITLE
DX: Makefile, .tool-versions (Python 3.11) e ajuste Quickstart (#158)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Verificar uso do template de PR
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/') && !startsWith(github.head_ref, 'ci/') && !startsWith(github.head_ref, 'docs/') && !startsWith(github.head_ref, 'tests/') }}
@@ -184,6 +186,9 @@ jobs:
 
       - name: ESLint (FSD boundaries + Zustand guard)
         run: pnpm lint
+
+      - name: Verificar necessidade de atualização de documentação
+        run: node scripts/ci/check-docs-needed.js
 
   pre-commit:
     name: Pre-commit (lint hooks)

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,4 @@
+python 3.11.9
 nodejs 20.17.0
 pnpm 9.12.2
+poetry 1.8.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ A pipeline principal executa e/ou exige:
 - Performance (k6 + Lighthouse budgets) quando aplicável.
 - Segurança (SAST/DAST/SCA, pgcrypto, SBOM) com enforcement estrito em `main`/release.
 - Threat model lint.
+- Verificação de documentação: falha PR quando há mudanças impactantes (CI/infra/versions/contracts)
+  sem atualização correspondente em `README.md`/`CONTRIBUTING.md`/`docs/`. Também verifica drift
+  básico das versões (Node de `.nvmrc`, Poetry pinado no workflow e Python do `pyproject.toml`) contra o README.
 - CI Outage Guard: fail‑open em branches não release para ferramentas de QA; fail‑closed em `main`/`release/*`/`hotfix/*`.
 - Pre-commit (lint hooks):
   - Em PRs: execução incremental por diff entre base e head (`--from-ref $BASE --to-ref $HEAD`).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+##
+## IABank — Atalhos de DX (delegam para scripts existentes)
+##
+
+.PHONY: help up down ps logs lint test test\:frontend test\:backend openapi contracts\:verify perf\:smoke sbom
+
+help: ## Mostra esta ajuda
+	@grep -E '^[a-zA-Z0-9_.:\\-]+:.*?## ' $(MAKEFILE_LIST) \
+	| sed -E 's/:.*?## /\t- /' \
+	| sed -E 's/^/make /' \
+	| sed -E 's/\\\:/:/g'
+
+# Orquestração local (fonte de verdade: scripts/dev/foundation-stack.sh)
+up: ## Sobe a stack local (docker ou nativa)
+	./scripts/dev/foundation-stack.sh up
+
+down: ## Derruba a stack local
+	./scripts/dev/foundation-stack.sh down
+
+ps: ## Lista status dos serviços
+	./scripts/dev/foundation-stack.sh ps
+
+logs: ## Segue logs (SERVICE=backend para um serviço específico)
+	./scripts/dev/foundation-stack.sh logs $(SERVICE)
+
+# Qualidade e testes (delegam para comandos existentes)
+lint: ## Lint do frontend (ESLint + regras FSD/Zustand)
+	pnpm lint
+
+test: ## Testes (suite existente)
+	pnpm test
+
+test\:frontend: ## Testes do frontend com cobertura
+	pnpm test:coverage
+
+test\:backend: ## Testes do backend (pytest)
+	poetry run pytest -q
+
+openapi: ## Lint + diff + codegen dos contratos OpenAPI
+	pnpm openapi
+
+contracts\:verify: ## Verifica contratos (OpenAPI + Pact)
+	pnpm contracts:verify
+
+perf\:smoke: ## Teste de performance (k6) em modo local
+	pnpm perf:smoke:local
+
+sbom: ## Gera SBOM do frontend
+	pnpm sbom:frontend

--- a/scripts/ci/check-docs-needed.js
+++ b/scripts/ci/check-docs-needed.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/*
+ Verificação geral de documentação:
+ - Falha o PR se houver mudanças em áreas sensíveis (versões/infra/CI/contracts)
+   sem alterações em arquivos de documentação (README/CONTRIBUTING/docs/**).
+ - Verifica drift básico de versões (Node major a partir de .nvmrc e Poetry pin do workflow)
+   contra o README.
+
+ Execução local (opcional):
+   node scripts/ci/check-docs-needed.js
+
+ No GitHub Actions, o script usa GITHUB_EVENT_PATH para detectar base SHA do PR/push.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+function readJSON(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readText(p) {
+  try {
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function git(args, opts = {}) {
+  return require('child_process').execSync(`git ${args}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], ...opts }).trim();
+}
+
+function unique(arr) {
+  return Array.from(new Set(arr));
+}
+
+function getBaseSha() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const event = readJSON(eventPath) || {};
+    if (event.pull_request && event.pull_request.base && event.pull_request.base.sha) {
+      return event.pull_request.base.sha;
+    }
+    if (event.before) return event.before;
+  }
+  // Fallbacks locais
+  try {
+    // Tenta merge-base com origin/main (se disponível)
+    return git('merge-base origin/main HEAD');
+  } catch {
+    try {
+      // Último commit
+      return git('rev-parse HEAD~1');
+    } catch {
+      // Repositório com 1 commit
+      return git('rev-parse HEAD');
+    }
+  }
+}
+
+function listChangedFiles(baseSha) {
+  try {
+    const out = git(`diff --name-only ${baseSha}..HEAD`);
+    return out.split('\n').filter(Boolean);
+  } catch {
+    try {
+      const out = git('diff --name-only HEAD~1..HEAD');
+      return out.split('\n').filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+}
+
+function matchAnyPrefix(file, prefixes) {
+  return prefixes.some((p) => file === p || file.startsWith(p.endsWith('/') ? p : p + '/'));
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const baseSha = getBaseSha();
+  const changed = listChangedFiles(baseSha);
+
+  // Áreas cujo ajuste costuma demandar atualização de docs
+  const impactPrefixes = [
+    '.nvmrc',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pyproject.toml',
+    'poetry.lock',
+    '.github/workflows/',
+    'infra/',
+    'contracts/api.yaml',
+  ];
+
+  // Locais considerados documentação
+  const docsPrefixes = [
+    'README.md',
+    'CONTRIBUTING.md',
+    'docs/',
+    'specs/',
+    'observabilidade/',
+  ];
+
+  const impactChanged = unique(changed.filter((f) => matchAnyPrefix(f, impactPrefixes)));
+  const docsChanged = unique(changed.filter((f) => matchAnyPrefix(f, docsPrefixes)));
+
+  let hadError = false;
+  const eventName = process.env.GITHUB_EVENT_NAME || '';
+
+  if (impactChanged.length > 0 && docsChanged.length === 0) {
+    const msgHead = 'Mudanças impactantes sem atualização de documentação detectada.';
+    const log = (level) => (text) => console.error(`::${level}::${text}`);
+    const emit = eventName === 'pull_request' ? log('error') : log('warning');
+    emit(msgHead);
+    console.error('Arquivos impactantes alterados:');
+    for (const f of impactChanged) console.error(`- ${f}`);
+    console.error('Sugestão: atualize README.md/CONTRIBUTING.md ou docs/ conforme aplicável.');
+    if (eventName === 'pull_request') hadError = true;
+  }
+
+  // Drift básico de versões
+  // Node major de .nvmrc vs README (busca "Node.js <major>")
+  const nvmrc = readText(path.join(repoRoot, '.nvmrc')).trim();
+  const nodeMajor = /^([0-9]+)/.exec(nvmrc)?.[1];
+  const readme = readText(path.join(repoRoot, 'README.md'));
+  if (nodeMajor && !new RegExp(`Node\\.js\\s+${nodeMajor}(?![0-9])`).test(readme)) {
+    const emit = eventName === 'pull_request' ? 'error' : 'warning';
+    console.error(`::${emit}::README não menciona Node.js ${nodeMajor} (extraído de .nvmrc=${nvmrc}).`);
+    if (eventName === 'pull_request') hadError = true;
+  }
+
+  // Poetry versão pinada no workflow vs README
+  const wf = readText(path.join(repoRoot, '.github/workflows/frontend-foundation.yml'));
+  const poetryPin = /poetry==([0-9]+\.[0-9]+\.[0-9]+)/.exec(wf)?.[1];
+  if (poetryPin && !readme.includes(`poetry==${poetryPin}`) && !readme.includes(`Poetry ${poetryPin}`)) {
+    const emit = eventName === 'pull_request' ? 'error' : 'warning';
+    console.error(`::${emit}::README não reflete Poetry ${poetryPin} (pin no workflow).`);
+    if (eventName === 'pull_request') hadError = true;
+  }
+
+  // Python versão principal de pyproject vs README
+  const pyproject = readText(path.join(repoRoot, 'pyproject.toml'));
+  const pyReq = /python\s*=\s*"\^([0-9]+\.[0-9]+)"/.exec(pyproject)?.[1];
+  if (pyReq && !new RegExp(`Python\\s+${pyReq}(?![0-9])`).test(readme)) {
+    const emit = eventName === 'pull_request' ? 'error' : 'warning';
+    console.error(`::${emit}::README não menciona Python ${pyReq} (de pyproject.toml).`);
+    if (eventName === 'pull_request') hadError = true;
+  }
+
+  if (hadError) {
+    process.exit(1);
+  } else {
+    console.log('::notice::Verificação de documentação OK.');
+  }
+}
+
+main();

--- a/specs/002-f-10-fundacao/quickstart.md
+++ b/specs/002-f-10-fundacao/quickstart.md
@@ -2,7 +2,7 @@
 
 ## 1. Pré-requisitos
 - Node.js 20.x, pnpm 9.x instalados.
-- Python 3.12 + Poetry para utilitários CLI.
+- Python 3.11 + Poetry 1.8.3 para utilitários CLI.
 - Docker/Docker Compose para stack backend + Redis + PostgreSQL.
 - Acesso ao Vault (`vault login`) e às chaves em `kv/foundation/frontend`:
   - `cspNonceSecret` → exportar em dev como `FOUNDATION_CSP_NONCE`


### PR DESCRIPTION
Este PR implementa a issue #158.

Principais pontos:
- Makefile: atalhos DX que apenas delegam a scripts existentes (sem lógica nova).
- .tool-versions: adiciona `python 3.11.9` e `poetry 1.8.3` (mantém `nodejs 20.17.0` e `pnpm 9.12.2`).
- Quickstart F-10: corrige pré-requisito para "Python 3.11 + Poetry 1.8.3".
- Gate de documentação: verificação de drift/atualização em PRs (Node/.nvmrc, Poetry do workflow, Python/pyproject, CI/infra/contracts) com integração no job Lint.

Validações:
- make help lista os targets; todos mapeiam para comandos existentes.
- Busca por "Python 3.12" em docs retorna vazio.
- Script de docs roda local e no CI.

Closes #158