### PR TITLE
chore(housekeeping): centraliza temporários/logs em artifacts/ e atualiza docs (fix #156)

### DIFF
--- a/.github/workflows/ci-outage-selftest.yml
+++ b/.github/workflows/ci-outage-selftest.yml
@@ -48,7 +48,7 @@ jobs:
           CI_OUTAGE_AXE_JOB_NAME: selftest-axe
           FOUNDATION_DEFAULT_TENANT: tenant-alfa
           # Simulate outage via local log with known patterns (read by script)
-          CI_OUTAGE_CHROMATIC_LOG: chromatic-selftest.log
+          CI_OUTAGE_CHROMATIC_LOG: artifacts/local/chromatic-selftest.log
           # Force non-release branch name to validate fail-open behavior (we also pass explicit JSON)
           GITHUB_REF_NAME: selftest-failopen
           # GitHub context (best effort; script tolerates missing PR)
@@ -56,10 +56,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "Running outage selftest (fail-open)..."
+          mkdir -p artifacts/local
           echo "ECONNRESET simulated by selftest" > "$CI_OUTAGE_CHROMATIC_LOG"
-          node scripts/dist/ci/handle-outage.js | tee selftest-output.json
+          node scripts/dist/ci/handle-outage.js | tee artifacts/local/selftest-output.json
           echo "--- Selftest output (truncated) ---"
-          head -n 50 selftest-output.json || true
+          head -n 50 artifacts/local/selftest-output.json || true
 
       - name: Upload outage report artifact (if any)
         if: always()
@@ -108,11 +109,12 @@ jobs:
           CI_OUTAGE_AXE_JOB_STATUS: success
           CI_OUTAGE_AXE_JOB_NAME: selftest-axe
           FOUNDATION_DEFAULT_TENANT: tenant-alfa
-          CI_OUTAGE_CHROMATIC_LOG: chromatic-selftest-fc.log
+          CI_OUTAGE_CHROMATIC_LOG: artifacts/local/chromatic-selftest-fc.log
           GITHUB_REF_NAME: main
         run: |
           set -euo pipefail
           echo "Running outage selftest (fail-closed expected on main)..."
+          mkdir -p artifacts/local
           echo "service unavailable (selftest)" > "$CI_OUTAGE_CHROMATIC_LOG"
           # The script should exit(1) because branch is main (release) and outage exists
           node scripts/dist/ci/handle-outage.js || echo "EXPECTED_FAIL_CLOSED"

--- a/docs/runbooks/evidences/frontend-foundation/v1.0/README.md
+++ b/docs/runbooks/evidences/frontend-foundation/v1.0/README.md
@@ -17,7 +17,7 @@ Responsáveis: Frontend Foundation Guild / Platform
     - Performance: success (histórico). ATUALIZAÇÃO 2025-11-08: gates agora são estritos também em PR; continuam publicando artefatos.
     - Security Checks: success (histórico). ATUALIZAÇÃO 2025-11-08: em PR passou a ser fail‑closed (sem fail‑open).
     - Threat Model Lint: success
-- Run manual (sanidade em main): ID 19048561651 (workflow_dispatch) — logs locais em `run.log`.
+- Run manual (sanidade em main): ID 19048561651 (workflow_dispatch) — logs locais em `artifacts/local/run.log`.
 
 ## Artefatos
 

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -140,7 +140,7 @@ Pontos de Contato
 ### Ações pendentes para fechar gates (antes do run final)
 
 - Visual/Chromatic: ajustar `fetch-depth: 0` no `actions/checkout` do job ou adicionar commits na branch para permitir baseline; validar cobertura ≥ 95% e anexar `chromatic-coverage.json`.
-- Performance: atualizar ação k6 para uma tag existente (`grafana/setup-k6-action@v1` ou equivalente), reexecutar; anexar `artifacts/k6-smoke.json` e relatórios Lighthouse.
+- Performance: atualizar ação k6 para uma tag existente (`grafana/setup-k6-action@v1` ou equivalente), reexecutar; anexar `artifacts/perf/k6-smoke.json` e relatórios Lighthouse.
 - Segurança: corrigir rule Semgrep com schema inválido; validar `pip-audit` com Poetry 1.8.3 (alinhado ao CI/Docker); migração para Poetry 2.x fica em backlog; garantir SBOM gerada e validada (upload OK).
 
 ### Evidências PR #12 — run verde

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sbom:frontend": "node scripts/sbom/generate-frontend.js",
     "audit:frontend": "pnpm --dir frontend audit --prod --audit-level=high --json",
     "perf:smoke": "node scripts/perf/run-smoke.js",
-    "perf:smoke:ci": "node scripts/perf/run-smoke.js --summary-export=artifacts/k6-smoke.json",
+    "perf:smoke:ci": "mkdir -p artifacts/perf && node scripts/perf/run-smoke.js --summary-export=artifacts/perf/k6-smoke.json",
     "perf:lighthouse": "pnpm --filter @iabank/frontend-foundation test:lighthouse",
     "perf:smoke:local": "FOUNDATION_PERF_MODE=local FOUNDATION_PERF_SKIP_BUILD=true FOUNDATION_PERF_VUS=1 pnpm perf:smoke:ci",
     "finops:report": "pnpm exec tsc -p tsconfig.scripts.json && node scripts/dist/finops/foundation-costs.js",

--- a/specs/002-f-10-fundacao/checklists/api.md
+++ b/specs/002-f-10-fundacao/checklists/api.md
@@ -7,20 +7,20 @@ Referências base:
 - Threat model: `docs/security/threat-models/frontend-foundation/v1.0.md`
 - Contratos: `contracts/api.yaml`, `contracts/api.previous.yaml`, regras: `contracts/.spectral.yaml`
 - CI (últimos runs):
-  - push: `push_run.log` (logs locais)
+  - push: `artifacts/local/push_run.log` (logs locais)
   - PR: (fornecer link do Actions ao último run verde do workflow)
-  - manual (sanidade, main): Run ID `19048561651` — logs: `run.log`
+  - manual (sanidade, main): Run ID `19048561651` — logs: `artifacts/local/run.log`
 - PRs relevantes: #10 (Merge validation v2 final), #11 (Cleanup pós-merge F‑10 CI)
 
 Especificidades obrigatórias deste tema: Spectral, OpenAPI-diff e Pact.
 
 Itens objetivos:
 - [x] Spectral (lint) sem erros bloqueantes
-  - Evidências: `push_run.log` (Contracts → "Spectral lint"): "No results with a severity of 'error' found!"; regras em `contracts/.spectral.yaml`.
+  - Evidências: `artifacts/local/push_run.log` (Contracts → "Spectral lint"): "No results with a severity of 'error' found!"; regras em `contracts/.spectral.yaml`.
 - [x] OpenAPI-diff sem breaking changes (comparação previous → current)
-  - Evidências: `push_run.log` (Contracts → "OpenAPI diff"): `"breakingDifferencesFound": false` comparando `contracts/api.previous.yaml` → `contracts/api.yaml`.
+  - Evidências: `artifacts/local/push_run.log` (Contracts → "OpenAPI diff"): `"breakingDifferencesFound": false` comparando `contracts/api.previous.yaml` → `contracts/api.yaml`.
 - [x] Pact (consumer verification) executado sem falhas
-  - Evidências: `push_run.log`/`run.log` (Contracts/Vitest) com interações Pact e testes passando (ex.: `tests/design-system/list-stories.pact.ts`).
+  - Evidências: `artifacts/local/push_run.log`/`artifacts/local/run.log` (Contracts/Vitest) com interações Pact e testes passando (ex.: `tests/design-system/list-stories.pact.ts`).
 - [x] Último run VERDE de PR para o job "Contracts (Spectral, OpenAPI Diff, Pact)"
   - Evidências (PR #12): job verde — https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406986661
 - [x] Runbook atualizado com resultados de contratos

--- a/specs/002-f-10-fundacao/checklists/geral.md
+++ b/specs/002-f-10-fundacao/checklists/geral.md
@@ -7,18 +7,18 @@ Referências base:
 - Dashboard: `observabilidade/dashboards/frontend-foundation.json`
 - Threat model: `docs/security/threat-models/frontend-foundation/v1.0.md`
 - CI (últimos runs):
-  - push: `push_run.log` (logs locais)
+  - push: `artifacts/local/push_run.log` (logs locais)
   - PR: (fornecer link do Actions ao último run verde do workflow)
-  - manual (sanidade, main): Run ID `19048561651` (evento `workflow_dispatch`) — logs: `run.log`.
+  - manual (sanidade, main): Run ID `19048561651` (evento `workflow_dispatch`) — logs: `artifacts/local/run.log`.
 - PRs relevantes: #10 (Merge validation v2 final), #11 (Cleanup pós-merge F‑10 CI)
 
 Itens objetivos (marcados apenas com evidências claras):
 - [x] Workflow de CI versionado e com jobs esperados (lint/test/contracts/visual/performance/security/threat-model-lint/ci-outage-guard)
   - Evidências: `.github/workflows/frontend-foundation.yml`
 - [x] Threat Model Lint OK para `v1.0`
-  - Evidências: `push_run.log` (Threat Model Lint) confirma: "[threat-model-lint] Artefato verificado com sucesso" em `docs/security/threat-models/frontend-foundation/v1.0.md`
+  - Evidências: `artifacts/local/push_run.log` (Threat Model Lint) confirma: "[threat-model-lint] Artefato verificado com sucesso" em `docs/security/threat-models/frontend-foundation/v1.0.md`
 - [x] Complexidade ciclomática (Radon) dentro do limite (<=10)
-  - Evidências: `push_run.log` (Vitest job → "Radon complexity gate"): "Complexidade ciclomática dentro do limite (<=10)."
+  - Evidências: `artifacts/local/push_run.log` (Vitest job → "Radon complexity gate"): "Complexidade ciclomática dentro do limite (<=10)."
 - [x] Lint (ESLint + FSD boundaries + guard de Zustand) aprovado
   - Evidências (PR #12): job Lint verde — https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406825581
 - [x] Cobertura (Vitest) ≥ 85% (statements/lines/functions)
@@ -38,7 +38,7 @@ Itens objetivos (marcados apenas com evidências claras):
 
 Atualizações recentes:
 - PR #12 (Evidências F‑10) mergeado. Run verde (PR): https://github.com/Tomvaz11/iabank/actions/runs/19050934281
-- Run manual (sanidade, main): ID 19048561651 — logs locais em `run.log`.
+- Run manual (sanidade, main): ID 19048561651 — logs locais em `artifacts/local/run.log`.
 
 Observações finais:
  

--- a/specs/002-f-10-fundacao/checklists/performance.md
+++ b/specs/002-f-10-fundacao/checklists/performance.md
@@ -6,7 +6,7 @@ Referências base:
 - Dashboard: `observabilidade/dashboards/frontend-foundation.json`
 - Threat model: `docs/security/threat-models/frontend-foundation/v1.0.md`
 - Artefatos: `observabilidade/data/lighthouse-latest.json`
-- CI (últimos runs): push (`push_run.log`), manual (`main`, Run ID `19048561651` → `run.log`), PR (fornecer link do último run verde)
+- CI (últimos runs): push (`artifacts/local/push_run.log`), manual (`main`, Run ID `19048561651` → `artifacts/local/run.log`), PR (fornecer link do último run verde)
 - PRs relevantes: #10, #11
 
 Especificidades obrigatórias: Lighthouse (LCP/TTI/TBT/CLS) e k6 smoke.

--- a/specs/002-f-10-fundacao/checklists/seguranca.md
+++ b/specs/002-f-10-fundacao/checklists/seguranca.md
@@ -5,20 +5,20 @@ Referências base:
 - Runbook: `docs/runbooks/frontend-foundation.md`
 - Dashboard: `observabilidade/dashboards/frontend-foundation.json`
 - Threat model: `docs/security/threat-models/frontend-foundation/v1.0.md`
-- CI (últimos runs): push (`push_run.log`), manual (`main`, Run ID `19048561651` → `run.log`), PR (fornecer link do último run verde)
+- CI (últimos runs): push (`artifacts/local/push_run.log`), manual (`main`, Run ID `19048561651` → `artifacts/local/run.log`), PR (fornecer link do último run verde)
 - PRs relevantes: #10, #11
 
 Especificidades obrigatórias: SAST/DAST/SCA/SBOM, CSP/Trusted Types, PII masking, RLS/pgcrypto.
 
 Itens objetivos:
 - [x] CSP & Trusted Types — política e testes
-  - Evidências: `frontend/tests/vite.csp.middleware.test.ts` (CSP+Trusted Types) e `frontend/tests/security/csp_trusted_types.spec.ts` (modo report→enforce) — ambos passam em `push_run.log` (Vitest).
+  - Evidências: `frontend/tests/vite.csp.middleware.test.ts` (CSP+Trusted Types) e `frontend/tests/security/csp_trusted_types.spec.ts` (modo report→enforce) — ambos passam em `artifacts/local/push_run.log` (Vitest).
 - [x] PII masking — telemetria/relato
-  - Evidências: `frontend/tests/otel/masking.spec.ts` com sucesso em `push_run.log`.
+  - Evidências: `frontend/tests/otel/masking.spec.ts` com sucesso em `artifacts/local/push_run.log`.
 - [x] RLS enforcement — testes de backend
-  - Evidências: `push_run.log` (Pytest) mostra `backend/apps/tenancy/tests/test_rls_enforcement.py ...` e `test_migration_rls.py .` passando.
+  - Evidências: `artifacts/local/push_run.log` (Pytest) mostra `backend/apps/tenancy/tests/test_rls_enforcement.py ...` e `test_migration_rls.py .` passando.
 - [x] pgcrypto — validação do script
-  - Evidências: step "Validação pgcrypto" imprime "json_payload protegido com pgcrypto." em `push_run.log`.
+  - Evidências: step "Validação pgcrypto" imprime "json_payload protegido com pgcrypto." em `artifacts/local/push_run.log`.
 - [x] SAST (Semgrep) — sem HIGH/CRITICAL em release
   - Evidências: job Security Checks verde no PR #12 (sem falhas bloqueantes) — https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54407027868; política fail‑closed aplicada em `main/releases/tags` e aceita no "Aceite Final (F‑10)".
 - [x] DAST (OWASP ZAP baseline) — sem falhas críticas

--- a/specs/002-f-10-fundacao/checklists/ux.md
+++ b/specs/002-f-10-fundacao/checklists/ux.md
@@ -6,16 +6,16 @@ Referências base:
 - Dashboard: `observabilidade/dashboards/frontend-foundation.json`
 - Threat model: `docs/security/threat-models/frontend-foundation/v1.0.md`
 - CI (últimos runs):
-  - push: `push_run.log`
+  - push: `artifacts/local/push_run.log`
   - PR: (fornecer link do Actions ao último run verde do workflow)
-  - manual (sanidade, main): Run ID `19048561651` — `run.log`.
+  - manual (sanidade, main): Run ID `19048561651` — `artifacts/local/run.log`.
 - PRs relevantes: #10, #11
 
 Especificidades obrigatórias: Storybook + test-runner (axe/WCAG) e Chromatic (condicional em PR).
 
 Itens objetivos:
 - [x] Storybook build gerado (estático)
-  - Evidências: `push_run.log` (job "Visual & Accessibility Gates" → "Build Storybook estático"), artefatos em `frontend/storybook-static`.
+  - Evidências: `artifacts/local/push_run.log` (job "Visual & Accessibility Gates" → "Build Storybook estático"), artefatos em `frontend/storybook-static`.
 - [x] Test‑runner do Storybook (axe/WCAG) sem violações (PR)
   - Evidências (PR #12): job Visual verde (test‑runner executado sem violações) — https://github.com/Tomvaz11/iabank/actions/runs/19050934281
 - [x] Chromatic executado em PR (condicional)


### PR DESCRIPTION
## Descrição
Centraliza logs e saídas temporárias em subpastas de artifacts/, alinhando scripts e referências em documentação. Mantém .coverage na raiz e não altera rotinas de limpeza.

Mudanças:
- CI selftest: logs do Outage Guard em artifacts/local/*.log e saída JSON em artifacts/local/selftest-output.json.
- Scripts: perf:smoke:ci agora exporta para artifacts/perf/k6-smoke.json (cria pasta automaticamente).
- Docs: referências a run.log/push_run.log na raiz migradas para artifacts/local/ nas checklists e evidências.
- Verificação de docs: script alerta referências antigas a logs na raiz (erro em PRs).

## Checklist
- [x] Título segue Conventional Commits.
- [x] Inclui pelo menos uma tag @SC-00x (ex.: @SC-001 para lead time de DX/housekeeping).
- [x] Não é PR isento de tag (@SC-00x) por prefixo.

## Contexto / Referências
- Issue #156
- @SC-001
