### PR TITLE
ci(perf): alinhar caminho do artefato k6 com mudança do #156

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -668,6 +668,7 @@ jobs:
         run: |
           mkdir -p artifacts
           mkdir -p artifacts/lighthouse
+          mkdir -p artifacts/perf
 
       - name: Executar k6 smoke (estrito)
         if: ${{ needs.changes.outputs.ui == 'true' }}
@@ -701,7 +702,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: performance-k6-smoke
-          path: artifacts/k6-smoke.json
+          path: artifacts/perf/k6-smoke.json
           retention-days: 14
 
       - name: Publicar relatórios Lighthouse

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -7,7 +7,7 @@ Reflete os gates constitucionais (v5.2.0) e ADRs 008–012.
 2. **tests-integration**: inclui cenários de RLS (`CREATE POLICY` + enforcement) e `factory-boy`.
 3. **tests-contract**: Spectral, openapi-diff, Pact (`.github/workflows/ci-contracts.yml`) com cenários de idempotência e concorrência.
 4. **tests-security**: SAST, DAST, SCA, verificação de pgcrypto/mascaramento (scripts do ADR-010).
-5. **tests-performance**: k6 com thresholds definidos nos SLOs aprovados (documentar no repositório de SLOs/SLA) e revisados semestralmente.
+5. **tests-performance**: k6 com thresholds definidos nos SLOs aprovados (documentar no repositório de SLOs/SLA) e revisados semestralmente. Artefato JSON: `artifacts/perf/k6-smoke.json`.
 6. **build-sbom**: Gera CycloneDX/SPDX.
 7. **iac-policy**: Terraform plan + OPA/Gatekeeper.
 8. **finops-tags**: Script para validar tagging obrigatório (Artigo XVI).


### PR DESCRIPTION
## Descrição
Ajusta o caminho do artefato do k6 no workflow principal para `artifacts/perf/k6-smoke.json`, alinhando `package.json` (perf:smoke:ci) após a reorganização de artifacts (#156).

## Checklist
- [x] Título segue Conventional Commits.
- [x] Inclui pelo menos uma tag @SC-00x (ex.: @SC-001).
- [x] Não é PR isento de tag (@SC-00x) por prefixo.

## Contexto / Referências
- Relaciona @SC-001
- Issue #156
