### PR TITLE
ci: uploads silenciosos e cache Semgrep (checks obrigatórios preservados) @SC-001

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -454,11 +454,12 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) || (github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/release/') || startsWith(github.ref,'refs/tags/'))) || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main' && !startsWith(github.ref,'refs/heads/release/') && !startsWith(github.ref,'refs/tags/') && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true')) }}
         run: poetry run python scripts/ci/check_python_complexity.py
       - name: Upload pytest logs
-        if: always()
+        if: ${{ always() && hashFiles('artifacts/pytest/**') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: pytest-logs
           path: artifacts/pytest
+          if-no-files-found: ignore
 
   contracts:
     name: Contracts (Spectral, OpenAPI Diff, Pact)
@@ -596,6 +597,7 @@ jobs:
           path: |
             frontend/storybook-static
             frontend/chromatic-coverage.json
+          if-no-files-found: ignore
           retention-days: 7
 
   performance:
@@ -698,21 +700,23 @@ jobs:
           fi
 
       - name: Publicar resultados k6
-        if: ${{ needs.changes.outputs.ui == 'true' }}
+        if: ${{ needs.changes.outputs.ui == 'true' && hashFiles('artifacts/perf/k6-smoke.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: performance-k6-smoke
           path: artifacts/perf/k6-smoke.json
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Publicar relatórios Lighthouse
-        if: ${{ always() && needs.changes.outputs.ui == 'true' }}
+        if: ${{ always() && needs.changes.outputs.ui == 'true' && (hashFiles('artifacts/lighthouse/**') != '' || hashFiles('observabilidade/data/lighthouse-latest.json') != '') }}
         uses: actions/upload-artifact@v4
         with:
           name: performance-lighthouse-budgets
           path: |
             artifacts/lighthouse
             observabilidade/data/lighthouse-latest.json
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Resumo dos budgets Lighthouse
@@ -807,6 +811,17 @@ jobs:
         if: ${{ needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Semgrep rules
+        if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.semgrep
+            ~/.cache/semgrep
+          key: ${{ runner.os }}-semgrep-v1-${{ hashFiles('scripts/security/semgrep.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-semgrep-v1-
+
       - name: Install Poetry (pin 1.8.x para compatibilidade do lock)
         if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.security == 'true' || env.CI_ENFORCE_FULL_SECURITY == 'true' }}
         run: |
@@ -867,11 +882,12 @@ jobs:
           fi
 
       - name: Upload ZAP artifacts
-        if: always()
+        if: ${{ always() && hashFiles('artifacts/zap/**') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: zap-reports
           path: artifacts/zap
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Resumo ZAP

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,11 @@ A pipeline principal executa e/ou exige:
   - O checkout do job usa `fetch-depth: 0` para garantir diffs confiáveis.
   - Hooks definidos em `.pre-commit-config.yaml` (ESLint/Ruff); o job grava um resumo no Job Summary.
 
+### CI: Gating de jobs e uploads
+- Jobs obrigatórios pela proteção de branch NÃO devem ser pulados no nível do job. Mantenha o gating por paths/refs no nível dos steps para preservar a presença dos checks (status “verde” quando não há trabalho).
+- Para uploads, evite ruído de “No files were found…” usando `if-no-files-found: ignore` e/ou condicionais com `hashFiles()` (ex.: `if: ${{ always() && hashFiles('artifacts/pytest/**') != '' }}`).
+- Segurança: reforçamos caches (Poetry/pip/pnpm e Semgrep) para reduzir tempo, mantendo execução completa em `main`/tags e execução limitada a paths relevantes em PRs.
+
 - Testes (gates por paths) — Lote 3:
   - “Vitest” (job `test-frontend`): prepara Node e executa Vitest quando `needs.changes.outputs.frontend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
   - “Pytest + Radon” (job `test-backend`): prepara Python/Poetry e executa Pytest/Radon quando `needs.changes.outputs.backend == 'true'` OU `needs.changes.outputs.tests == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.


### PR DESCRIPTION
Este PR implementa as melhorias solicitadas na issue #175 sem alterar a lista/nomes dos checks obrigatórios.\n\nMudanças principais:\n- Uploads sem ruído: adiciona `if-no-files-found: ignore` e condicionais `hashFiles()` nos artefatos (pytest, ZAP, k6, Lighthouse, Chromatic).\n- Segurança: adiciona cache para regras/artefatos do Semgrep, reduzindo a duração do job Security.\n- Documentação: orientações sobre gating por steps e uploads silenciosos no CONTRIBUTING.\n\nNotas:\n- Mantidos os nomes dos jobs para não impactar a proteção da main.\n- Gating permanece no nível de steps para checks obrigatórios, evitando que desapareçam do PR.\n\nFixes #175

## Checklist
- [x] inclui pelo menos uma tag @SC-00x
- [x] atualiza documentação relevante (CONTRIBUTING)
- [x] mantém nomes de checks obrigatórios

Compliance: @SC-001