### PR TITLE
ci: padroniza uploads silenciosos em workflows secundários (hashFiles + if-no-files-found)

### DIFF
--- a/.github/workflows/ci-outage-selftest.yml
+++ b/.github/workflows/ci-outage-selftest.yml
@@ -77,7 +77,7 @@ jobs:
           head -n 50 artifacts/local/selftest-output.json || true
 
       - name: Upload outage report artifact (if any)
-        if: always()
+        if: ${{ always() && hashFiles('observabilidade/data/ci-outages.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ci-outage-selftest
@@ -134,7 +134,7 @@ jobs:
           node scripts/dist/ci/handle-outage.js || echo "EXPECTED_FAIL_CLOSED"
 
       - name: Upload outage report artifact (if any)
-        if: always()
+        if: ${{ always() && hashFiles('observabilidade/data/ci-outages.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ci-outage-selftest-fail-closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ A pipeline principal executa e/ou exige:
 - Para uploads, evite ruído de “No files were found…” usando `if-no-files-found: ignore` e/ou condicionais com `hashFiles()` (ex.: `if: ${{ always() && hashFiles('artifacts/pytest/**') != '' }}`).
 - Segurança: reforçamos caches (Poetry/pip/pnpm e Semgrep) para reduzir tempo, mantendo execução completa em `main`/tags e execução limitada a paths relevantes em PRs.
 
+- Padrão em workflows secundários: quando o artefato é opcional (diagnóstico/logs) e pode não existir, aplique `if: ${{ always() && hashFiles('<caminho/**>') != '' }}` junto de `if-no-files-found: ignore`. Ex.: no "CI Outage Selftest", o upload de `observabilidade/data/ci-outages.json` é condicionado com `hashFiles()` para evitar avisos e manter os checks obrigatórios presentes.
+
 - Testes (gates por paths) — Lote 3:
   - “Vitest” (job `test-frontend`): prepara Node e executa Vitest quando `needs.changes.outputs.frontend == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.
   - “Pytest + Radon” (job `test-backend`): prepara Python/Poetry e executa Pytest/Radon quando `needs.changes.outputs.backend == 'true'` OU `needs.changes.outputs.tests == 'true'` (em PR/dev). Em `main`/`release/*`/tags, sempre executa.


### PR DESCRIPTION
Este PR aplica o padrão de uploads silenciosos (hashFiles() + if-no-files-found: ignore) aos workflows secundários conforme a issue #177.\n\nMudanças:\n- ci-outage-selftest.yml: adiciona gate com `hashFiles('observabilidade/data/ci-outages.json')` aos steps de upload, mantendo `if-no-files-found: ignore`.\n\nNotas:\n- Não há passos de upload em `ci-contracts.yml`, `ci-vault-rotate.yml` e `renovate-validation.yml`, portanto nenhuma alteração neles.\n- Nomes de jobs, steps e artefatos foram preservados.\n\nValidação esperada:\n- Em execuções onde o arquivo não é gerado, o step é pulado (sem warnings) e o job permanece verde.\n\nCloses #177