### PR TITLE
OpenAPI 3.1: migrar contratos e union types (Closes #181)

### DIFF
--- a/contracts/api.yaml
+++ b/contracts/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: IABANK Frontend Foundation API
   version: 0.1.0
@@ -539,9 +539,8 @@ components:
           type: string
           format: uuid
         tenantId:
-          type: string
+          type: [string, 'null']
           format: uuid
-          nullable: true
         componentId:
           type: string
         storyId:

--- a/specs/002-f-10-fundacao/contracts/frontend-foundation.yaml
+++ b/specs/002-f-10-fundacao/contracts/frontend-foundation.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: IABANK Frontend Foundation API
   version: 0.1.0
@@ -539,9 +539,8 @@ components:
           type: string
           format: uuid
         tenantId:
-          type: string
+          type: [string, 'null']
           format: uuid
-          nullable: true
         componentId:
           type: string
         storyId:


### PR DESCRIPTION
Este PR atualiza os contratos para **OpenAPI 3.1.0** e substitui `nullable: true` por union types (JSON Schema 2020-12), conforme plano da issue #181.\n\nAlterações:\n- contracts/api.yaml: `openapi: 3.1.0` e `tenantId` ajustado para `type: [string, "null"]`.\n- Codegen validado localmente com `pnpm openapi:generate` (sem quebras).\n\nValidações locais:\n- `pnpm openapi:lint` OK (Spectral).\n- Build do frontend OK.\n\nBase:** este PR depende do PR 1 (Redocly CLI + backend enum + docs).**\n