### PR TITLE
ci(contracts): publicar changelog do oasdiff como artifact @SC-001

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -77,6 +77,25 @@ jobs:
           fi
         shell: bash
 
+      - name: OpenAPI changelog (texto)
+        if: ${{ always() }}
+        run: |
+          mkdir -p artifacts/contracts
+          if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
+            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+          else
+            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+          fi
+        shell: bash
+
+      - name: Upload artifacts (contracts)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-diff
+          path: artifacts/contracts
+          if-no-files-found: ignore
+
       - name: Pact contract tests
         run: |
           if command -v pnpm >/dev/null 2>&1 && pnpm run | grep -q 'test:pact'; then

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -539,6 +539,24 @@ jobs:
         if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
         run: pnpm pact:verify
 
+      - name: OpenAPI changelog (texto)
+        if: ${{ always() }}
+        run: |
+          mkdir -p artifacts/contracts
+          if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
+            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+          else
+            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+          fi
+
+      - name: Upload artifacts (contracts)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-diff
+          path: artifacts/contracts
+          if-no-files-found: ignore
+
   visual-accessibility:
     name: Visual & Accessibility Gates
     runs-on: ubuntu-latest

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -63,6 +63,10 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
 ## Atualizações (2025-11-17) — Lote 5
 - Contracts: renomeado o job para "Contracts (Spectral, oasdiff, Pact)".
 - Instalação do oasdiff nos workflows passou a usar o repositório oficial (`github.com/oasdiff/oasdiff/releases`).
+- Publicação de changelog textual (oasdiff) como artifact:
+  - Steps adicionados em `.github/workflows/ci-contracts.yml` e no job `contracts` do `.github/workflows/frontend-foundation.yml` geram `artifacts/contracts/changelog.txt` via `oasdiff changelog ... -f text`.
+  - O diretório `artifacts/contracts` é publicado como artifact `contracts-diff` com `actions/upload-artifact@v4` (`if-no-files-found: ignore`).
+  - Objetivo: auditoria de mudanças de OpenAPI em PRs e branch principal.
 
 ## Prova de TDD (Art. III)
 - PRs DEVEM evidenciar “vermelho → verde” para mudanças de código:


### PR DESCRIPTION
## Descrição

Implementa #210: adiciona steps pós-breaking para gerar changelog textual (oasdiff) e publicar artifact `contracts-diff` em:
- `.github/workflows/ci-contracts.yml`
- `.github/workflows/frontend-foundation.yml`

Closes #210

## Checklist

- [x] Título segue Conventional Commits (ex.: `ci(contracts): descrição`).
- [x] Inclui pelo menos uma tag `@SC-00x` no título ou corpo.
- [x] Não é PR isento de tag (@SC-00x) por prefixo.
- [x] Mudança limitada a workflows; sem impacto de UI.

## Contexto / Referências

- Issue: #210
- Evidência de artifact `contracts-diff` no CI Contracts: presente com `changelog.txt`.
