### PR TITLE
ci(contracts): evitar artifact vazio do changelog; mensagem quando sem baseline/sem oasdiff @SC-001

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -80,11 +80,19 @@ jobs:
       - name: OpenAPI changelog (texto)
         if: ${{ always() }}
         run: |
+          set +e
           mkdir -p artifacts/contracts
+          OUT="artifacts/contracts/changelog.txt"
           if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+            if command -v oasdiff >/dev/null 2>&1; then
+              if ! oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > "$OUT"; then
+                echo "Falha ao gerar changelog com oasdiff; verifique os logs do step de diff." > "$OUT"
+              fi
+            else
+              echo "oasdiff indisponível neste run; sem mudanças de contracts ou instalação não executada." > "$OUT"
+            fi
           else
-            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+            echo "Baseline ou spec ausente; nada a relatar (sem changelog)." > "$OUT"
           fi
         shell: bash
 

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -542,11 +542,19 @@ jobs:
       - name: OpenAPI changelog (texto)
         if: ${{ always() }}
         run: |
+          set +e
           mkdir -p artifacts/contracts
+          OUT="artifacts/contracts/changelog.txt"
           if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+            if command -v oasdiff >/dev/null 2>&1; then
+              if ! oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > "$OUT"; then
+                echo "Falha ao gerar changelog com oasdiff; verifique os logs do step de diff." > "$OUT"
+              fi
+            else
+              echo "oasdiff indisponível neste run; sem mudanças de contracts ou instalação não executada." > "$OUT"
+            fi
           else
-            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+            echo "Baseline ou spec ausente; nada a relatar (sem changelog)." > "$OUT"
           fi
 
       - name: Upload artifacts (contracts)

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -71,9 +71,10 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
 ### Nota — artifact de changelog (oasdiff)
 - Nome do artifact: `contracts-diff`; arquivo: `artifacts/contracts/changelog.txt`.
 - Sem diferenças entre `contracts/api.previous.yaml` e `contracts/api.yaml`, o arquivo pode vir vazio (0 bytes), conforme versão/comportamento do `oasdiff`.
-- Se a baseline (`contracts/api.previous.yaml`) não existir, o step registra aviso e o artifact pode não ser publicado (upload tolerante: `if-no-files-found: ignore`).
+- Se a baseline (`contracts/api.previous.yaml`) não existir, o step grava mensagem informativa no arquivo (e o upload é tolerante com `if-no-files-found: ignore`).
 - Para redefinir o delta, atualize a baseline quando “virar” a versão do contrato:
   - `cp contracts/api.yaml contracts/api.previous.yaml` (commit sugerido: `chore(contracts): refresh baseline`).
+- Em runs onde o `oasdiff` não é instalado (ex.: PRs sem mudanças em `contracts/**` no workflow principal), o arquivo contém mensagem informativa em vez de ficar vazio.
 - Quando há mudanças, a saída lista severidade (`error|warning|info`), alvo (endpoint/componente) e contexto.
 
 ## Prova de TDD (Art. III)


### PR DESCRIPTION
Recria o PR #218 a partir de  atualizado para evitar estado "DIRTY/CONFLICTING" no GitHub.\n\n- Melhora o step de changelog do oasdiff para escrever mensagem quando sem baseline ou sem  no run, evitando  0 bytes.\n- Atualiza docs em  com o novo comportamento.\n\nCloses #218 (superseded).