### PR TITLE
ci(contracts): adicionar resumo do changelog no Job Summary (contracts-diff) @SC-001

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -104,6 +104,20 @@ jobs:
           path: artifacts/contracts
           if-no-files-found: ignore
 
+      - name: Resumo do OpenAPI changelog
+        if: ${{ always() }}
+        run: |
+          OUT="artifacts/contracts/changelog.txt"
+          echo "### OpenAPI Changelog (oasdiff)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -s "$OUT" ]; then
+            first=$(head -n1 "$OUT" | tr -d '\r')
+            echo "- Summary: $first" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Summary: arquivo vazio (sem diffs ou step não executado)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- Artifact: contracts-diff (artifacts/contracts/changelog.txt)" >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
       - name: Pact contract tests
         run: |
           if command -v pnpm >/dev/null 2>&1 && pnpm run | grep -q 'test:pact'; then

--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -80,11 +80,19 @@ jobs:
       - name: OpenAPI changelog (texto)
         if: ${{ always() }}
         run: |
+          set +e
           mkdir -p artifacts/contracts
+          OUT="artifacts/contracts/changelog.txt"
           if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+            if command -v oasdiff >/dev/null 2>&1; then
+              if ! oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > "$OUT"; then
+                echo "Falha ao gerar changelog com oasdiff; verifique os logs do step de diff." > "$OUT"
+              fi
+            else
+              echo "oasdiff indisponível neste run; sem mudanças de contracts ou instalação não executada." > "$OUT"
+            fi
           else
-            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+            echo "Baseline ou spec ausente; nada a relatar (sem changelog)." > "$OUT"
           fi
         shell: bash
 

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -565,6 +565,19 @@ jobs:
           path: artifacts/contracts
           if-no-files-found: ignore
 
+      - name: Resumo do OpenAPI changelog
+        if: ${{ always() }}
+        run: |
+          OUT="artifacts/contracts/changelog.txt"
+          echo "### OpenAPI Changelog (oasdiff)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -s "$OUT" ]; then
+            first=$(head -n1 "$OUT" | tr -d '\r')
+            echo "- Summary: $first" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Summary: arquivo vazio (sem diffs ou step não executado)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- Artifact: contracts-diff (artifacts/contracts/changelog.txt)" >> "$GITHUB_STEP_SUMMARY"
+
   visual-accessibility:
     name: Visual & Accessibility Gates
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -542,11 +542,19 @@ jobs:
       - name: OpenAPI changelog (texto)
         if: ${{ always() }}
         run: |
+          set +e
           mkdir -p artifacts/contracts
+          OUT="artifacts/contracts/changelog.txt"
           if [ -f contracts/api.yaml ] && [ -f contracts/api.previous.yaml ]; then
-            oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > artifacts/contracts/changelog.txt || true
+            if command -v oasdiff >/dev/null 2>&1; then
+              if ! oasdiff changelog contracts/api.previous.yaml contracts/api.yaml -f text > "$OUT"; then
+                echo "Falha ao gerar changelog com oasdiff; verifique os logs do step de diff." > "$OUT"
+              fi
+            else
+              echo "oasdiff indisponível neste run; sem mudanças de contracts ou instalação não executada." > "$OUT"
+            fi
           else
-            echo "::warning::OpenAPI baseline missing; skipping changelog text"
+            echo "Baseline ou spec ausente; nada a relatar (sem changelog)." > "$OUT"
           fi
 
       - name: Upload artifacts (contracts)

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -67,6 +67,7 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
   - Steps adicionados em `.github/workflows/ci-contracts.yml` e no job `contracts` do `.github/workflows/frontend-foundation.yml` geram `artifacts/contracts/changelog.txt` via `oasdiff changelog ... -f text`.
   - O diretório `artifacts/contracts` é publicado como artifact `contracts-diff` com `actions/upload-artifact@v4` (`if-no-files-found: ignore`).
   - Objetivo: auditoria de mudanças de OpenAPI em PRs e branch principal.
+  - Job Summary: o workflow escreve um resumo com a primeira linha do changelog no `$GITHUB_STEP_SUMMARY` e referencia o artifact `contracts-diff`.
 
 ### Nota — artifact de changelog (oasdiff)
 - Nome do artifact: `contracts-diff`; arquivo: `artifacts/contracts/changelog.txt`.

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -71,9 +71,10 @@ Nota operacional: esta seção foi ajustada apenas para validar o comportamento 
 ### Nota — artifact de changelog (oasdiff)
 - Nome do artifact: `contracts-diff`; arquivo: `artifacts/contracts/changelog.txt`.
 - Sem diferenças entre `contracts/api.previous.yaml` e `contracts/api.yaml`, o arquivo pode vir vazio (0 bytes), conforme versão/comportamento do `oasdiff`.
-- Se a baseline (`contracts/api.previous.yaml`) não existir, o step registra aviso e o artifact pode não ser publicado (upload tolerante: `if-no-files-found: ignore`).
+- Se a baseline (`contracts/api.previous.yaml`) não existir, o step grava mensagem informativa no arquivo (e o upload é tolerante com `if-no-files-found: ignore`).
 - Para redefinir o delta, atualize a baseline quando “virar” a versão do contrato:
   - `cp contracts/api.yaml contracts/api.previous.yaml` (commit sugerido: `chore(contracts): refresh baseline`).
+- Em runs onde o `oasdiff` não é instalado (ex.: PRs sem mudanças em `contracts/**` no workflow principal), o arquivo contém mensagem informativa em vez de ficar vazio.
 - Quando há mudanças, a saída lista severidade (`error|warning|info`), alvo (endpoint/componente) e contexto.
 
 ## Prova de TDD (Art. III)


### PR DESCRIPTION
Adiciona resumo do oasdiff no Job Summary dos workflows para facilitar revisão sem baixar artifacts.\n\n-  e : novo step "Resumo do OpenAPI changelog" escreve a primeira linha do  no  e referencia o artifact .\n- : documenta o resumo no Job Summary.\n