### PR TITLE
CI/Contracts: cache do oasdiff por versão (v1.11.7)

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -513,19 +513,38 @@ jobs:
         if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
         run: pnpm install --frozen-lockfile
 
-      - name: Install oasdiff (v1.11.7, linux_amd64)
+      - name: Restore oasdiff cache
         if: ${{ needs.changes.outputs.contracts == 'true' }}
+        id: cache-oasdiff
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/oasdiff/1.11.7
+          key: oasdiff-${{ runner.os }}-v1.11.7
+
+      - name: Install oasdiff (v1.11.7, linux_amd64) [cache miss]
+        if: ${{ needs.changes.outputs.contracts == 'true' && steps.cache-oasdiff.outputs.cache-hit != 'true' }}
         run: |
           set -euo pipefail
           OASDIFF_VERSION="1.11.7"
           OASDIFF_URL="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
-          INSTALL_DIR="$RUNNER_TEMP/oasdiff-bin"
+          INSTALL_DIR="$HOME/.cache/oasdiff/${OASDIFF_VERSION}"
           mkdir -p "$INSTALL_DIR"
           echo "Baixando oasdiff de $OASDIFF_URL"
           curl -sSL "$OASDIFF_URL" -o "$INSTALL_DIR/oasdiff.tar.gz"
           tar -xzf "$INSTALL_DIR/oasdiff.tar.gz" -C "$INSTALL_DIR"
+          rm -f "$INSTALL_DIR/oasdiff.tar.gz"
           chmod +x "$INSTALL_DIR/oasdiff"
-          echo "$INSTALL_DIR" >> $GITHUB_PATH
+
+      - name: Add oasdiff to PATH
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "$HOME/.cache/oasdiff/1.11.7" >> $GITHUB_PATH
+          if ! command -v oasdiff >/dev/null 2>&1; then
+            echo "oasdiff não encontrado no PATH após setup" >&2
+            exit 1
+          fi
+          oasdiff --version || true
 
       - name: Spectral lint (US1/US2/US3)
         if: ${{ needs.changes.outputs.contracts == 'true' }}

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -160,3 +160,12 @@ Notas de governança relacionadas:
 - Observações:
   - Não registre a chave em issues/PRs/logs. Evite `set -x` em scripts que imprimam variáveis.
   - A substituição é imediata para novos jobs; jobs já em execução continuarão com o token que receberam no início da execução.
+
+## Atualizações (2025-11-17) — Lote 6
+- Contracts (workflow principal): cache do binário do oasdiff por versão para reduzir tempo de setup.
+  - Workflow: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, OpenAPI Diff, Pact)").
+  - Versão pinada: `v1.11.7` (linux_amd64), conforme relatório da migração (#181).
+  - Cache: `actions/cache@v4` com chave `oasdiff-${{ runner.os }}-v1.11.7`.
+  - Instalação em cache miss: download/extract para `~/.cache/oasdiff/1.11.7` e `chmod +x`.
+  - PATH: adiciona `~/.cache/oasdiff/1.11.7` via `GITHUB_PATH`.
+  - Motivação: eliminar download repetido do binário entre execuções e acelerar o job Contracts.


### PR DESCRIPTION
Este PR implementa cache do binário do oasdiff por versão para reduzir o tempo de setup no job Contracts.\n\n- Adiciona actions/cache@v4 com chave 'oasdiff-[runner.os]-v1.11.7'\n- Em cache hit: reutiliza diretório no GITHUB_PATH\n- Em cache miss: baixa para ~/.cache/oasdiff/1.11.7, torna executável e adiciona ao PATH\n\nCritério de aceite: execuções subsequentes mostram cache hit e menor duração do step de instalação.\n\nCloses #211