### PR TITLE
docs: relatório da Issue #211 (cache do oasdiff v1.11.7 no CI)

### DIFF
--- a/RELATORIO_ISSUE_211_CACHE_OASDIFF.md
+++ b/RELATORIO_ISSUE_211_CACHE_OASDIFF.md
@@ -1,0 +1,56 @@
+# Relatório – Issue #211: Cache do binário do oasdiff por versão (CI/Contracts)
+
+Data: 2025-11-17  
+Responsável: Automação/Assistente (via gh CLI)
+
+## Contexto
+- Issue: CI/Contracts: Cache do binário do oasdiff por versão (#211)
+- Objetivo: reduzir o tempo de setup no CI cacheando o binário do `oasdiff` (v1.11.7), reutilizando-o via `GITHUB_PATH` quando houver cache hit.
+- Referência técnica: RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF.md (adoção do `oasdiff` v1.11.7 e posicionamento dos steps no pipeline).
+
+## Execução (passo a passo)
+1) Leitura da issue #211 com `gh issue view` para confirmar objetivo, passos e critérios de aceite.
+2) Inspeção dos workflows: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, OpenAPI Diff, Pact)").
+3) Implementação do cache no workflow principal (job Contracts):
+   - Adicionado `actions/cache@v4` com chave `oasdiff-${{ runner.os }}-v1.11.7`.
+   - Em cache miss: download/extract do binário oficial v1.11.7 para `~/.cache/oasdiff/1.11.7`, `chmod +x`.
+   - Adição do diretório ao `PATH` via `GITHUB_PATH` e verificação `oasdiff --version`.
+4) Commit e PR (#222): abertura do PR “CI/Contracts: cache do oasdiff por versão (v1.11.7)” com auto‑merge (squash) habilitado.
+5) Correção de gate de documentação (Lint → check-docs-needed):
+   - Atualizada `docs/pipelines/ci-required-checks.md` com a seção “Atualizações (2025‑11‑17) — Lote 6” documentando o cache do `oasdiff`.
+   - Novo commit enviado ao mesmo PR.
+6) Merge automático do PR após checks verdes (auto‑merge): PR #222 merged em `main` (commit `b45081c`).
+7) Operações de higiene:
+   - Remoção das branches locais e remotas utilizadas.
+   - Sincronização do repositório local com `origin/main`.
+8) Encerramento: issue #211 fechada com comentário de conclusão.
+
+## Mudanças por arquivo
+- `.github/workflows/frontend-foundation.yml` (job Contracts):
+  - Passos adicionados:
+    - “Restore oasdiff cache” (actions/cache@v4, chave `oasdiff-${{ runner.os }}-v1.11.7`, path `~/.cache/oasdiff/1.11.7`).
+    - “Install oasdiff (v1.11.7, linux_amd64) [cache miss]” (download + extract para `~/.cache/oasdiff/1.11.7`).
+    - “Add oasdiff to PATH” (inclusão em `GITHUB_PATH` + `oasdiff --version`).
+- `docs/pipelines/ci-required-checks.md`:
+  - Seção “Atualizações (2025-11-17) — Lote 6” descrevendo a versão, chave de cache, diretório e motivação.
+
+## Alinhamento com o Relatório #181
+- Versão do `oasdiff`: v1.11.7 (conforme definido).
+- Instalação por binário oficial (releases do projeto) e uso no job Contracts (conforme definido).
+- Diferença intencional de diretório: uso de `~/.cache/oasdiff/1.11.7` em vez de `$RUNNER_TEMP/oasdiff-bin` (exemplo do anexo #181). Justificativa: diretório sob `~/.cache` é estável e idiomático para binários cacheados. Requisitos essenciais (pin de versão, chave de cache, GITHUB_PATH) mantidos.
+
+## Evidências
+- PR: https://github.com/Tomvaz11/iabank/pull/222 (merged)
+- Commit de merge em main: `b45081c` — “CI/Contracts: cache do oasdiff por versão (v1.11.7) (#222)”
+- Run do CI em main (sucesso): https://github.com/Tomvaz11/iabank/actions/runs/19432105368
+- Issue fechada: https://github.com/Tomvaz11/iabank/issues/211
+
+## Observações
+- Investigação de referência da issue: o arquivo `RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF.md` está na raiz. A dificuldade inicial em encontrá‑lo ocorreu por busca de conteúdo em vez de nome; resolvido via `rg --files | rg 'RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF\.md$'`.
+
+## Resultado
+- Critérios da issue atendidos: cache hit em execuções subsequentes e menor duração no step de instalação do `oasdiff`.
+- Repositório sincronizado, sem branches residuais da tarefa, issue encerrada.
+
+***
+Gerado automaticamente nesta interação para rastreabilidade e auditoria.


### PR DESCRIPTION
Adiciona relatório detalhado da execução da Issue #211 na raiz do repositório.\n\nConteúdo:\n- Contexto, objetivo e referências\n- Passo a passo da implementação (workflow + docs)\n- Mudanças por arquivo e alinhamento com o relatório #181\n- Evidências (PR #222, commit de merge b45081c, run do CI em main)\n- Resultado e conclusão\n\nNota: a issue #211 já foi encerrada após o merge do PR #222.