### PR TITLE
ci(contracts): cache do oasdiff v1.11.7 no workflow dedicado (ci-contracts)

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -46,19 +46,39 @@ jobs:
         run: pnpm install --frozen-lockfile
         shell: bash
 
-      # Instala oasdiff (binário) sem depender do toolchain Go
-      - name: Install oasdiff (v1.11.7, linux_amd64)
+      # Cache do oasdiff por versão (v1.11.7)
+      - name: Restore oasdiff cache
+        id: cache-oasdiff
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/oasdiff/1.11.7
+          key: oasdiff-${{ runner.os }}-v1.11.7
+
+      - name: Install oasdiff (v1.11.7, linux_amd64) [cache miss]
+        if: ${{ steps.cache-oasdiff.outputs.cache-hit != 'true' }}
+        id: install-oasdiff
         run: |
           set -euo pipefail
           OASDIFF_VERSION="1.11.7"
           OASDIFF_URL="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
-          INSTALL_DIR="$RUNNER_TEMP/oasdiff-bin"
+          INSTALL_DIR="$HOME/.cache/oasdiff/${OASDIFF_VERSION}"
           mkdir -p "$INSTALL_DIR"
           echo "Baixando oasdiff de $OASDIFF_URL"
           curl -sSL "$OASDIFF_URL" -o "$INSTALL_DIR/oasdiff.tar.gz"
           tar -xzf "$INSTALL_DIR/oasdiff.tar.gz" -C "$INSTALL_DIR"
+          rm -f "$INSTALL_DIR/oasdiff.tar.gz"
           chmod +x "$INSTALL_DIR/oasdiff"
-          echo "$INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Add oasdiff to PATH
+        run: |
+          set -euo pipefail
+          echo "$HOME/.cache/oasdiff/1.11.7" >> $GITHUB_PATH
+          if ! command -v oasdiff >/dev/null 2>&1; then
+            echo "oasdiff não encontrado no PATH após setup" >&2
+            exit 1
+          fi
+          oasdiff --version || true
         shell: bash
 
       - name: Spectral lint (via pnpm openapi:lint)

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -169,6 +169,7 @@ Notas de governança relacionadas:
   - Instalação em cache miss: download/extract para `~/.cache/oasdiff/1.11.7` e `chmod +x`.
   - PATH: adiciona `~/.cache/oasdiff/1.11.7` via `GITHUB_PATH`.
   - Motivação: eliminar download repetido do binário entre execuções e acelerar o job Contracts.
+  - Também aplicado no workflow dedicado de contratos: `.github/workflows/ci-contracts.yml` (mesma chave e diretório de cache; adiciona o PATH e valida `oasdiff --version`).
 
 ## Atualizações (2025-11-17) — Baseline 3.1 (sombra)
 - Label `contracts:baseline-3.1` em PRs faz o workflow `ci-contracts.yml` usar um baseline alternativo em `contracts/api.baseline-3.1.yaml`.


### PR DESCRIPTION
Aplica cache do binário do oasdiff (v1.11.7) no workflow dedicado de contratos para acelerar feedback em PRs só de contracts.\n\n- actions/cache@v4 com chave 'oasdiff-[runner.os]-v1.11.7' e diretório '~/.cache/oasdiff/1.11.7'\n- Instalação apenas em cache miss; adiciona PATH via GITHUB_PATH; valida 'oasdiff --version'\n- docs: atualiza ci-required-checks.md (Lote 6) indicando aplicação também no workflow dedicado\n\nBenefícios: feedback mais rápido, menos flakiness/concorrência, artifacts consistentes, resiliência de gating e performance com cache.\n