### PR TITLE
docs(contributing): baseline 3.1 (sombra) via label

### DIFF
--- a/.github/workflows/ci-contracts.yml
+++ b/.github/workflows/ci-contracts.yml
@@ -46,19 +46,39 @@ jobs:
         run: pnpm install --frozen-lockfile
         shell: bash
 
-      # Instala oasdiff (binário) sem depender do toolchain Go
-      - name: Install oasdiff (v1.11.7, linux_amd64)
+      # Cache do oasdiff por versão (v1.11.7)
+      - name: Restore oasdiff cache
+        id: cache-oasdiff
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/oasdiff/1.11.7
+          key: oasdiff-${{ runner.os }}-v1.11.7
+
+      - name: Install oasdiff (v1.11.7, linux_amd64) [cache miss]
+        if: ${{ steps.cache-oasdiff.outputs.cache-hit != 'true' }}
+        id: install-oasdiff
         run: |
           set -euo pipefail
           OASDIFF_VERSION="1.11.7"
           OASDIFF_URL="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
-          INSTALL_DIR="$RUNNER_TEMP/oasdiff-bin"
+          INSTALL_DIR="$HOME/.cache/oasdiff/${OASDIFF_VERSION}"
           mkdir -p "$INSTALL_DIR"
           echo "Baixando oasdiff de $OASDIFF_URL"
           curl -sSL "$OASDIFF_URL" -o "$INSTALL_DIR/oasdiff.tar.gz"
           tar -xzf "$INSTALL_DIR/oasdiff.tar.gz" -C "$INSTALL_DIR"
+          rm -f "$INSTALL_DIR/oasdiff.tar.gz"
           chmod +x "$INSTALL_DIR/oasdiff"
-          echo "$INSTALL_DIR" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Add oasdiff to PATH
+        run: |
+          set -euo pipefail
+          echo "$HOME/.cache/oasdiff/1.11.7" >> $GITHUB_PATH
+          if ! command -v oasdiff >/dev/null 2>&1; then
+            echo "oasdiff não encontrado no PATH após setup" >&2
+            exit 1
+          fi
+          oasdiff --version || true
         shell: bash
 
       - name: Spectral lint (via pnpm openapi:lint)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,13 @@ A pipeline principal executa e/ou exige:
   - O checkout do job usa `fetch-depth: 0` para garantir diffs confiáveis.
   - Hooks definidos em `.pre-commit-config.yaml` (ESLint/Ruff); o job grava um resumo no Job Summary.
 
+### Contratos: Baseline alternativo (3.1) — dry‑run por label
+- Como usar: aplique o label do PR `contracts:baseline-3.1` para que os workflows comparem o contrato atual (`contracts/api.yaml`) contra `contracts/api.baseline-3.1.yaml` em vez de `contracts/api.previous.yaml`.
+- Onde atua:
+  - Workflow `ci-contracts.yml`: step de diff usa `OPENAPI_BASELINE` quando o label está presente, chamando o wrapper `contracts/scripts/openapi-diff.sh`.
+  - Workflow principal (`frontend-foundation.yml`): detecta o label e exporta `OPENAPI_BASELINE` para o step de diff e para o changelog.
+- Wrapper de diff: `contracts/scripts/openapi-diff.sh` seleciona o baseline por prioridade: `--baseline PATH` > variável `OPENAPI_BASELINE` > `contracts/api.previous.yaml`. O script imprime no log qual baseline foi escolhido.
+
 ### CI: Gating de jobs e uploads
 - Jobs obrigatórios pela proteção de branch NÃO devem ser pulados no nível do job. Mantenha o gating por paths/refs no nível dos steps para preservar a presença dos checks (status “verde” quando não há trabalho).
 - Para uploads, evite ruído de “No files were found…” usando `if-no-files-found: ignore` e/ou condicionais com `hashFiles()` (ex.: `if: ${{ always() && hashFiles('artifacts/pytest/**') != '' }}`).

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -169,6 +169,7 @@ Notas de governança relacionadas:
   - Instalação em cache miss: download/extract para `~/.cache/oasdiff/1.11.7` e `chmod +x`.
   - PATH: adiciona `~/.cache/oasdiff/1.11.7` via `GITHUB_PATH`.
   - Motivação: eliminar download repetido do binário entre execuções e acelerar o job Contracts.
+  - Também aplicado no workflow dedicado de contratos: `.github/workflows/ci-contracts.yml` (mesma chave e diretório de cache; adiciona o PATH e valida `oasdiff --version`).
 
 ## Atualizações (2025-11-17) — Baseline 3.1 (sombra)
 - Label `contracts:baseline-3.1` em PRs faz o workflow `ci-contracts.yml` usar um baseline alternativo em `contracts/api.baseline-3.1.yaml`.


### PR DESCRIPTION
Adiciona instruções no CONTRIBUTING sobre o uso do label `contracts:baseline-3.1` para dry-run do baseline 3.1 (sem promover `api.previous.yaml`).\n\n- Onde atua: `.github/workflows/ci-contracts.yml` e `.github/workflows/frontend-foundation.yml`\n- Wrapper: `contracts/scripts/openapi-diff.sh` (precedência: flag > env > padrão).