### PR TITLE
CI/Contracts: renomear required check para "Contracts (Spectral, oasdiff, Pact)" (fase 1) #208

### DIFF
--- a/.github/workflows/frontend-foundation.yml
+++ b/.github/workflows/frontend-foundation.yml
@@ -610,6 +610,135 @@ jobs:
           fi
           echo "- Artifact: contracts-diff (artifacts/contracts/changelog.txt)" >> "$GITHUB_STEP_SUMMARY"
 
+  contracts_oasdiff:
+    name: Contracts (Spectral, oasdiff, Pact)
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect baseline via PR label (contracts:baseline-3.1)
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'contracts:baseline-3.1') }}
+        run: |
+          echo "OPENAPI_BASELINE=contracts/api.baseline-3.1.yaml" >> "$GITHUB_ENV"
+          echo "Usando baseline alternativo por label: $OPENAPI_BASELINE"
+        shell: bash
+
+      - name: Resumo de mudanças (contracts)
+        run: |
+          echo "Contracts changed? -> ${{ needs.changes.outputs.contracts }}"
+
+      - name: Setup pnpm
+        if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore oasdiff cache
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        id: cache-oasdiff-dup
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/oasdiff/1.11.7
+          key: oasdiff-${{ runner.os }}-v1.11.7
+
+      - name: Install oasdiff (v1.11.7, linux_amd64) [cache miss]
+        if: ${{ needs.changes.outputs.contracts == 'true' && steps.cache-oasdiff-dup.outputs.cache-hit != 'true' }}
+        run: |
+          set -euo pipefail
+          OASDIFF_VERSION="1.11.7"
+          OASDIFF_URL="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
+          INSTALL_DIR="$HOME/.cache/oasdiff/${OASDIFF_VERSION}"
+          mkdir -p "$INSTALL_DIR"
+          echo "Baixando oasdiff de $OASDIFF_URL"
+          curl -sSL "$OASDIFF_URL" -o "$INSTALL_DIR/oasdiff.tar.gz"
+          tar -xzf "$INSTALL_DIR/oasdiff.tar.gz" -C "$INSTALL_DIR"
+          rm -f "$INSTALL_DIR/oasdiff.tar.gz"
+          chmod +x "$INSTALL_DIR/oasdiff"
+
+      - name: Add oasdiff to PATH
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: |
+          set -euo pipefail
+          echo "$HOME/.cache/oasdiff/1.11.7" >> $GITHUB_PATH
+          if [ ! -x "$HOME/.cache/oasdiff/1.11.7/oasdiff" ]; then
+            echo "oasdiff não encontrado em $HOME/.cache/oasdiff/1.11.7" >&2
+            ls -la "$HOME/.cache/oasdiff/1.11.7" || true
+            exit 1
+          fi
+      - name: Verify oasdiff
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: |
+          oasdiff --version || ~/.cache/oasdiff/1.11.7/oasdiff --version || true
+
+      - name: Spectral lint (US1/US2/US3)
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: pnpm openapi:lint
+
+      - name: OpenAPI diff foundation spec
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: pnpm openapi:diff
+
+      - name: Pact consumer verification (US1/US2/US3)
+        if: ${{ needs.changes.outputs.contracts == 'true' || needs.changes.outputs.frontend == 'true' }}
+        run: pnpm pact:verify
+
+      - name: OpenAPI changelog (texto)
+        if: ${{ always() }}
+        run: |
+          set +e
+          mkdir -p artifacts/contracts
+          OUT="artifacts/contracts/changelog.txt"
+          BASELINE_PATH="${OPENAPI_BASELINE:-contracts/api.previous.yaml}"
+          if [ -f contracts/api.yaml ] && [ -f "$BASELINE_PATH" ]; then
+            if command -v oasdiff >/dev/null 2>&1; then
+              if ! oasdiff changelog "$BASELINE_PATH" contracts/api.yaml -f text > "$OUT"; then
+                echo "Falha ao gerar changelog com oasdiff; verifique os logs do step de diff." > "$OUT"
+              fi
+            else
+              echo "oasdiff indisponível neste run; sem mudanças de contracts ou instalação não executada." > "$OUT"
+            fi
+          else
+            echo "Baseline ou spec ausente; nada a relatar (sem changelog)." > "$OUT"
+          fi
+
+      - name: Upload artifacts (contracts)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-diff
+          path: artifacts/contracts
+          if-no-files-found: ignore
+
+      - name: Resumo do OpenAPI changelog
+        if: ${{ always() }}
+        run: |
+          OUT="artifacts/contracts/changelog.txt"
+          echo "### OpenAPI Changelog (oasdiff)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -s "$OUT" ]; then
+            first=$(head -n1 "$OUT" | tr -d '\r')
+            echo "- Summary: $first" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Summary: arquivo vazio (sem diffs ou step não executado)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- Artifact: contracts-diff (artifacts/contracts/changelog.txt)" >> "$GITHUB_STEP_SUMMARY"
+
   visual-accessibility:
     name: Visual & Accessibility Gates
     runs-on: ubuntu-latest

--- a/RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF.md
+++ b/RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF.md
@@ -109,7 +109,7 @@ Este relatório documenta as decisões, mudanças e validações da migração p
 ## Recomendações adicionais e operações
 
 3) Nome do job do Required Check (merge)
-- Manter o nome exatamente como protegido hoje: "Contracts (Spectral, OpenAPI Diff, Pact)" (Branch Protection exige este contexto).
+- Nome padronizado do job no CI: "Contracts (Spectral, oasdiff, Pact)" (ver proteção de branch atualizada).
 - Se optarmos por renomear no futuro (ex.: citar explicitamente "oasdiff"), primeiro atualize os Required Checks da branch `main` para evitar bloqueio de merge.
 
 4) Versão do oasdiff (pin) e revisão periódica

--- a/RELATORIO_ISSUE_211_CACHE_OASDIFF.md
+++ b/RELATORIO_ISSUE_211_CACHE_OASDIFF.md
@@ -10,7 +10,7 @@ Responsável: Automação/Assistente (via gh CLI)
 
 ## Execução (passo a passo)
 1) Leitura da issue #211 com `gh issue view` para confirmar objetivo, passos e critérios de aceite.
-2) Inspeção dos workflows: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, OpenAPI Diff, Pact)").
+2) Inspeção dos workflows: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, oasdiff, Pact)").
 3) Implementação do cache no workflow principal (job Contracts):
    - Adicionado `actions/cache@v4` com chave `oasdiff-${{ runner.os }}-v1.11.7`.
    - Em cache miss: download/extract do binário oficial v1.11.7 para `~/.cache/oasdiff/1.11.7`, `chmod +x`.

--- a/docs/pipelines/ci-required-checks.md
+++ b/docs/pipelines/ci-required-checks.md
@@ -97,7 +97,7 @@ Estes são os contextos atualmente exigidos na proteção da branch `main` (Bran
 - Lint
 - Vitest
 - Pytest + Radon
-- Contracts (Spectral, OpenAPI Diff, Pact)
+- Contracts (Spectral, oasdiff, Pact)
 - Visual & Accessibility Gates
 - Performance Budgets
 - Security Checks
@@ -163,7 +163,7 @@ Notas de governança relacionadas:
 
 ## Atualizações (2025-11-17) — Lote 6
 - Contracts (workflow principal): cache do binário do oasdiff por versão para reduzir tempo de setup.
-  - Workflow: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, OpenAPI Diff, Pact)").
+  - Workflow: `.github/workflows/frontend-foundation.yml` (job "Contracts (Spectral, oasdiff, Pact)").
   - Versão pinada: `v1.11.7` (linux_amd64), conforme relatório da migração (#181).
   - Cache: `actions/cache@v4` com chave `oasdiff-${{ runner.os }}-v1.11.7`.
   - Instalação em cache miss: download/extract para `~/.cache/oasdiff/1.11.7` e `chmod +x`.

--- a/docs/runbooks/frontend-foundation.md
+++ b/docs/runbooks/frontend-foundation.md
@@ -128,7 +128,7 @@ Pontos de Contato
   - Vitest (na época incluía Pytest; hoje separado em “Vitest” e “Pytest + Radon”): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406870319 (success)
     - Coverage Vitest: All files — Statements 95.17%, Lines 95.17%, Functions 88.88%, Branches 84.75.
     - Coverage Pytest: TOTAL 87%.
-  - Contracts (Spectral, OpenAPI Diff, Pact): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406986661 (success)
+  - Contracts (Spectral, oasdiff, Pact): https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54406986661 (success)
   - Visual & Accessibility Gates: https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54407027880 (failure)
     - Motivo: Chromatic falhou por histórico git raso ("Found only one commit").
   - Performance Budgets: https://github.com/Tomvaz11/iabank/actions/runs/19049757588/job/54407027840 (failure)


### PR DESCRIPTION
Este PR executa a fase 1 da issue #208:\n\n- Duplica o job de Contracts no workflow principal com o novo nome: \n  - "Contracts (Spectral, oasdiff, Pact)"\n  - Mantém o job atual ("Contracts (Spectral, OpenAPI Diff, Pact)") em paralelo.\n- Atualiza documentação onde o nome antigo aparecia.\n\nPróximos passos pós-merge (fase 2):\n- Remover o contexto antigo da Branch Protection (já adicionado o novo sem remover o antigo).\n- Validar 1 PR com ambos os checks verdes; depois remover o contexto antigo.\n\nArquivos principais:\n- .github/workflows/frontend-foundation.yml\n- docs/pipelines/ci-required-checks.md\n- RELATORIO_ISSUE_181_MIGRACAO_OPENAPI31_OASDIFF.md\n- RELATORIO_ISSUE_211_CACHE_OASDIFF.md\n\nNotas:\n- Este PR não remove o job antigo para evitar quebra temporária de proteção; a remoção pode ser tratada em PR de limpeza após a transição.\n