### PR TITLE
chore(contracts): promover baseline OpenAPI 3.1.0 (api.previous.yaml) @SC-001

### DIFF
--- a/RELATORIO_ISSUE_207_PROMOVER_BASELINE_OPENAPI31.md
+++ b/RELATORIO_ISSUE_207_PROMOVER_BASELINE_OPENAPI31.md
@@ -1,0 +1,51 @@
+# Relatório — Issue #207: Contracts: Promover baseline OpenAPI 3.1.0 (api.previous.yaml)
+
+Data: 2025-11-17
+Issue: https://github.com/Tomvaz11/iabank/issues/207
+
+## Objetivo
+Promover o baseline utilizado nos diffs de contratos do OpenAPI de 3.0.3 para 3.1.0, garantindo que quebras reais não sejam mascaradas pelo baseline desatualizado.
+
+## Contexto
+- Após a migração do contrato para OpenAPI 3.1 + oasdiff, o arquivo `contracts/api.previous.yaml` ainda estava em `openapi: 3.0.3` (placeholder mínimo).
+- Havia um baseline "sombra" (`contracts/api.baseline-3.1.yaml`) usado via label para dry‑run no CI.
+
+## Ações Executadas
+1. Criação de branch de trabalho: `chore/contracts/promote-baseline-openapi-31-207`.
+2. Promoção do baseline:
+   - Copiado `contracts/api.yaml` → `contracts/api.previous.yaml`.
+   - Verificado que `contracts/api.previous.yaml:1` agora contém `openapi: 3.1.0`.
+3. Validações locais:
+   - Spectral: `pnpm openapi:lint` — sem erros.
+   - oasdiff (breaking): `pnpm openapi:diff` — sem diferenças breaking (baseline == atual após promoção).
+   - Geração de cliente: `pnpm openapi:generate` — concluída.
+   - Pact: `pnpm pact:verify` — 3 testes passando.
+   - Observação: instalado `oasdiff` localmente em `.bin/oasdiff` (v1.11.7) para viabilizar o diff local.
+4. Documentação:
+   - Este relatório foi adicionado para rastreabilidade e auditoria.
+   - Demais documentos (runbooks e pipelines) já descrevem o procedimento de atualização do baseline e o uso do baseline alternativo via label; nenhuma atualização adicional necessária.
+
+## Commits Relevantes
+- chore(contracts): promover baseline OpenAPI 3.1.0 (api.previous.yaml)
+
+## Arquivos Alterados/Adicionados
+- M `contracts/api.previous.yaml`
+- A `RELATORIO_ISSUE_207_PROMOVER_BASELINE_OPENAPI31.md`
+
+## Decisões Tomadas
+- Promover diretamente o baseline principal para 3.1.0, dada a estabilização do contrato e a existência de baseline sombra já utilizada em PRs anteriores.
+- Manter o mecanismo de baseline alternativo por label como ferramenta de governança (dry‑run) para futuras mudanças.
+
+## Pendências Identificadas e Tratadas
+- Ausência do binário `oasdiff` no ambiente local: solucionado com instalação do release oficial (v1.11.7) em `.bin/`.
+- Nenhum arquivo temporário/caches incluído no commit; repositório mantido limpo.
+
+## Próximos Passos
+- Monitorar 1 ciclo de PR após a promoção para confirmar ausência de regressões (gate “Contracts (Spectral, oasdiff, Pact)” deve permanecer verde).
+- Caso ocorram mudanças, o changelog textual do `oasdiff` seguirá publicado como artifact de CI (`contracts-diff`).
+
+## Evidências (execução local)
+- Spectral: sem erros (severity error = 0).
+- oasdiff breaking: nenhuma saída de breaking.
+- Pact: 1 arquivo/3 testes passando sob `frontend`.
+

--- a/contracts/api.previous.yaml
+++ b/contracts/api.previous.yaml
@@ -1,26 +1,35 @@
-openapi: 3.0.3
+openapi: 3.1.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 info:
-  title: Placeholder API
-  version: 0.0.1
+  title: IABANK Frontend Foundation API
+  version: 0.1.0
   description: |
-    Baseline mínima utilizada para diffs de contratos da fundação frontend.
+    Contratos oficiais que integram frontend foundation com serviços multi-tenant
+    de temas, scaffolding FSD e métricas SC-001 a SC-005.
   contact:
     name: Frontend Foundation Guild
     email: fe-foundation@iabank.com
 servers:
-  - url: https://api.placeholder.test
-    description: Ambiente placeholder
+  - url: https://api.iabank.com
+    description: Produção
+  - url: https://staging-api.iabank.com
+    description: Homologação
 tags:
+  - name: Tenants
+    description: Gerenciamento de temas e escopos multi-tenant.
+  - name: FrontendFoundation
+    description: Operações de scaffolding e métricas SC.
+  - name: DesignSystem
+    description: Artefatos do design system multi-tenant.
   - name: Health
-    description: Operações de verificação de integridade do serviço placeholder.
+    description: Monitoramento de integridade dos serviços fundamentais.
 paths:
   /health:
     get:
-      tags:
-        - Health
-      operationId: getHealthCheck
-      description: Retorna o status de saúde do serviço de fundação frontend.
+      tags: [Health]
       summary: Health check
+      description: Retorna o status de saúde do serviço de fundação frontend.
+      operationId: getHealthCheck
       responses:
         '200':
           description: OK
@@ -32,3 +41,543 @@ paths:
                   status:
                     type: string
                     example: ok
+  /api/v1/tenants/{tenantId}/themes/current:
+    get:
+      tags: [Tenants]
+      summary: Recuperar tokens ativos do tenant corrente
+      description: >
+        Retorna o conjunto de tokens fundacionais, semânticos e de componentes
+        aplicados ao tenant corrente. Respeita RLS (Art. XIII) e mascaramento de PII
+        em logs. Respostas incluem ETag para controle de concorrência em caches front-end.
+      operationId: getTenantTheme
+      parameters:
+        - $ref: '#/components/parameters/TenantIdPath'
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/TraceParent'
+        - $ref: '#/components/parameters/TraceState'
+      responses:
+        '200':
+          description: Tokens retornados com sucesso.
+          headers:
+            ETag:
+              $ref: '#/components/headers/ETag'
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantThemeResponse'
+        '304':
+          description: Não modificado (comparação via If-None-Match).
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - OAuth2ClientCreds: [tokens.read]
+  /api/v1/tenants/{tenantId}/features/scaffold:
+    post:
+      tags: [FrontendFoundation]
+      summary: Registrar scaffolding de uma feature FSD
+      description: >
+        Endpoint idempotente responsável por registrar, validar e auditar o scaffolding
+        de uma nova feature FSD. Requer chave de idempotência, executa validações de lint
+        e propaga métricas SC-001/SC-003.
+      operationId: registerFeatureScaffold
+      parameters:
+        - $ref: '#/components/parameters/TenantIdPath'
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/TraceParent'
+        - $ref: '#/components/parameters/TraceState'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeatureScaffoldRequest'
+      responses:
+        '201':
+          description: Scaffolding registrado com sucesso.
+          headers:
+            Location:
+              description: URI do recurso criado.
+              schema:
+                type: string
+                format: uri
+            Idempotency-Key:
+              $ref: '#/components/headers/IdempotencyKey'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureScaffoldResponse'
+        '202':
+          description: Scaffolding aceito e em processamento assíncrono.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+      security:
+        - OAuth2ClientCreds: [scaffolding.write]
+      x-idempotency:
+        - header: Idempotency-Key
+        - ttlSeconds: 86400
+        - uniquenessScope: tenantId + featureSlug
+  /api/v1/tenant-metrics/{tenantId}/sc:
+    get:
+      tags: [FrontendFoundation]
+      summary: Consultar métricas SC agregadas por tenant
+      description: >
+        Fornece métricas SC-001 a SC-005 agregadas por tenant, alimentadas pelos
+        pipelines CI/CD (Chromatic, Lighthouse, Pact). Resultados mascaram PII e
+        são paginados para relatórios.
+      operationId: listTenantSuccessMetrics
+      parameters:
+        - $ref: '#/components/parameters/TenantIdPath'
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/TraceParent'
+        - $ref: '#/components/parameters/TraceState'
+      responses:
+        '200':
+          description: Página de métricas retornada.
+          headers:
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantMetricPage'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - OAuth2ClientCreds: [metrics.read]
+  /api/v1/design-system/stories:
+    get:
+      tags: [DesignSystem]
+      summary: Listar stories multi-tenant com status de acessibilidade
+      description: >
+        Disponibiliza stories publicados para consumo por Chromatic/Storybook,
+        com metadados de cobertura visual e auditoria axe-core. Utiliza ETag e paginação.
+      operationId: listDesignSystemStories
+      parameters:
+        - $ref: '#/components/parameters/TenantHeaderOptional'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/PageSize'
+        - in: query
+          name: componentId
+          schema:
+            type: string
+          description: Filtrar por componente (`shared/ui/button`).
+        - in: query
+          name: tag
+          schema:
+            type: string
+          description: "Filtrar por tag (ex.: `critical`)."
+        - $ref: '#/components/parameters/TraceParent'
+        - $ref: '#/components/parameters/TraceState'
+      responses:
+        '200':
+          description: Lista de stories.
+          headers:
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DesignSystemStoryPage'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - OAuth2ClientCreds: [design-system.read]
+components:
+  securitySchemes:
+    OAuth2ClientCreds:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://identity.iabank.com/oauth/token
+          scopes:
+            tokens.read: Acessar temas de tenant.
+            scaffolding.write: Registrar scaffolding FSD.
+            metrics.read: Ler métricas SC agregadas.
+            design-system.read: Consumir stories multi-tenant.
+  parameters:
+    TenantIdPath:
+      name: tenantId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Identificador do tenant (UUID).
+    TenantHeader:
+      name: X-Tenant-Id
+      in: header
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: >
+        Tenant corrente propagado pelo gateway. Deve coincidir com o `tenantId` da rota.
+    TenantHeaderOptional:
+      name: X-Tenant-Id
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: >
+        Tenant solicitado; se omitido usa o tenant default do subdomínio.
+        Em desenvolvimento/local sem subdomínio, o fallback é `tenant-default`
+        (configuração de ambiente). Em staging/prod, o subdomínio prevalece e
+        o header é apenas filtro/otimização.
+    TraceParent:
+      name: traceparent
+      in: header
+      required: false
+      schema:
+        type: string
+      description: Cabeçalho W3C Trace Context.
+    TraceState:
+      name: tracestate
+      in: header
+      required: false
+      schema:
+        type: string
+      description: Cabeçalho W3C Trace Context state.
+    PageNumber:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      description: Página solicitada (1-indexed).
+    PageSize:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 25
+      description: Tamanho da página.
+  headers:
+    ETag:
+      description: Hash padrão W/"..." para controle de concorrência.
+      schema:
+        type: string
+    IdempotencyKey:
+      description: Eco da chave de idempotência utilizada na requisição.
+      schema:
+        type: string
+    RateLimitLimit:
+      description: Número máximo de requisições permitidas na janela atual.
+      schema:
+        type: string
+    RateLimitRemaining:
+      description: Requisições restantes na janela atual.
+      schema:
+        type: string
+    RateLimitReset:
+      description: Tempo até reset da janela (epoch seconds).
+      schema:
+        type: integer
+        format: int64
+    RetryAfter:
+      description: Tempo (em segundos ou data HTTP) para nova tentativa após 429.
+      schema:
+        oneOf:
+          - type: integer
+          - type: string
+            format: date-time
+  responses:
+    NotFound:
+      description: Recurso não encontrado.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    BadRequest:
+      description: Requisição inválida (erro de validação).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    Conflict:
+      description: Recurso já existente ou versão desatualizada (ETag).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    UnprocessableEntity:
+      description: Erros semânticos (lint, testes) bloqueando publicação.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    TooManyRequests:
+      description: Rate limiting atingido.
+      headers:
+        RateLimit-Limit:
+          $ref: '#/components/headers/RateLimitLimit'
+        RateLimit-Remaining:
+          $ref: '#/components/headers/RateLimitRemaining'
+        RateLimit-Reset:
+          $ref: '#/components/headers/RateLimitReset'
+        Retry-After:
+          $ref: '#/components/headers/RetryAfter'
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+  schemas:
+    ProblemDetails:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - traceId
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+        traceId:
+          type: string
+        violations:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+    TenantThemeResponse:
+      type: object
+      required:
+        - tenantId
+        - version
+        - generatedAt
+        - categories
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        version:
+          type: string
+          pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        generatedAt:
+          type: string
+          format: date-time
+        categories:
+          type: object
+          additionalProperties:
+            type: object
+            description: Mapa de tokens (`token -> valor`).
+          description: Tokens agrupados (`foundation`, `semantic`, `component`).
+        wcagReport:
+          type: object
+          description: Resumo das medições WCAG (contraste, status).
+          additionalProperties: true
+    FeatureScaffoldRequest:
+      type: object
+      required:
+        - featureSlug
+        - initiatedBy
+        - slices
+        - lintCommitHash
+        - scReferences
+      properties:
+        featureSlug:
+          type: string
+          pattern: '^[a-z0-9-]+$'
+        initiatedBy:
+          type: string
+          format: uuid
+        slices:
+          type: array
+          items:
+            type: object
+            required:
+              - slice
+              - files
+            properties:
+              slice:
+                type: string
+                enum: [app, pages, features, entities, shared]
+              files:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - path
+                    - checksum
+                  properties:
+                    path:
+                      type: string
+                    checksum:
+                      type: string
+                      description: SHA-256 do arquivo gerado.
+        lintCommitHash:
+          type: string
+          pattern: '^[0-9a-f]{40}$'
+        scReferences:
+          type: array
+          items:
+            type: string
+            pattern: '^@SC-00[1-5]$'
+        durationMs:
+          type: integer
+          minimum: 0
+        metadata:
+          type: object
+          description: "Campos adicionais (ex.: versão do CLI)."
+          additionalProperties: true
+    FeatureScaffoldResponse:
+      type: object
+      required:
+        - scaffoldId
+        - tenantId
+        - status
+        - recordedAt
+      properties:
+        scaffoldId:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [initiated, linted, tested, published]
+        recordedAt:
+          type: string
+          format: date-time
+        metrics:
+          type: array
+          items:
+            $ref: '#/components/schemas/SuccessMetric'
+    SuccessMetric:
+      type: object
+      required:
+        - code
+        - value
+        - collectedAt
+      properties:
+        code:
+          type: string
+          enum: [SC-001, SC-002, SC-003, SC-004, SC-005]
+        value:
+          type: number
+        collectedAt:
+          type: string
+          format: date-time
+        source:
+          type: string
+          enum: [ci, chromatic, lighthouse, manual]
+    TenantMetricPage:
+      type: object
+      required:
+        - data
+        - pagination
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SuccessMetric'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    DesignSystemStoryPage:
+      type: object
+      required:
+        - data
+        - pagination
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DesignSystemStory'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    DesignSystemStory:
+      type: object
+      required:
+        - id
+        - componentId
+        - storyId
+        - coveragePercent
+        - axeStatus
+        - chromaticBuild
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: [string, 'null']
+          format: uuid
+        componentId:
+          type: string
+        storyId:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        coveragePercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        axeStatus:
+          type: string
+          enum: [pass, fail, warn]
+        chromaticBuild:
+          type: string
+        storybookUrl:
+          type: string
+          format: uri
+        updatedAt:
+          type: string
+          format: date-time
+    Pagination:
+      type: object
+      required:
+        - page
+        - perPage
+        - totalItems
+        - totalPages
+      properties:
+        page:
+          type: integer
+        perPage:
+          type: integer
+        totalItems:
+          type: integer
+        totalPages:
+          type: integer


### PR DESCRIPTION
Closes #207\n\n- Promove baseline para 3.1.0 copiando api.yaml -> api.previous.yaml.\n- Validações locais: Spectral OK, oasdiff (breaking) sem diffs, Pact verde (3 testes).\n- Reporte detalhado: RELATORIO_ISSUE_207_PROMOVER_BASELINE_OPENAPI31.md.\n\nCritérios de prontidão e governança:\n- O baseline 3.1 estava sendo exercitado via label (sombra).\n- Monitoraremos 1 ciclo de PR após a promoção (Contracts gate).